### PR TITLE
Slice 1: project skeleton, Cobra wiring, CI, GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: jdx/mise-action@v4
+      - run: goreleaser release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "files need gofmt:"
+            echo "$unformatted"
+            gofmt -d .
+            exit 1
+          fi
+      - run: go vet ./...
+      - run: go test ./...
+      - run: golangci-lint run

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Built binaries
+/vp
+/vp.exe
+
+# GoReleaser output
+/dist/
+
+# Coverage
+coverage.out
+coverage.html
+
+# Editor / OS noise
+.DS_Store
+*.swp

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - revive
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,44 @@
+version: 2
+
+project_name: vp
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: vp
+    main: .
+    binary: vp
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/ThomasK33/vp/internal/version.Version={{.Version}}
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: vp
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: checksums.txt
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-snapshot-{{ .ShortCommit }}"
+
+release:
+  draft: false
+  prerelease: auto

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thomas Kosiewski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# vp
+
+A small, language-agnostic CLI for staging semver bump intent in Git. Stages
+**plans** that collapse into version-file updates at release time. Deliberately
+does *not* generate changelogs or release notes.
+
+> Status: pre-v0.1, under construction.
+
+See [`CONTEXT.md`](./CONTEXT.md) for the domain glossary and
+[`docs/adr/`](./docs/adr/) for architectural decisions.
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE).

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var addCmd = &cobra.Command{
+	Use:   "add <component> <bump>",
+	Short: "Add a plan file declaring component bumps.",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return errors.New("not yet implemented")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(addCmd)
+}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var applyCmd = &cobra.Command{
+	Use:   "apply",
+	Short: "Collapse pending plans, update version files, and consume the plans.",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return errors.New("not yet implemented")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(applyCmd)
+}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Validate that every affected component is covered by a pending plan.",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return errors.New("not yet implemented")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(checkCmd)
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Write a starter vp.yaml.",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return errors.New("not yet implemented")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,33 @@
+// Package cmd wires the vp Cobra command tree.
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/ThomasK33/vp/internal/version"
+)
+
+// Exit codes follow the convention documented in the PRD:
+//
+//	0 - success
+//	1 - vp check failure (missing plans)
+//	2 - usage / config error
+//	3 - runtime error
+const exitRuntimeError = 3
+
+var rootCmd = &cobra.Command{
+	Use:     "vp",
+	Short:   "Stage semver bump intent in Git.",
+	Long:    "vp stages plans that collapse into version-file updates at release time. It deliberately does not generate changelogs or release notes.",
+	Version: version.Version,
+	// Stub failures shouldn't dump the full help text.
+	SilenceUsage: true,
+}
+
+// Execute runs the root command and returns the process exit code.
+func Execute() int {
+	if err := rootCmd.Execute(); err != nil {
+		return exitRuntimeError
+	}
+	return 0
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Print pending plans, resolved bumps, and current/next versions.",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return errors.New("not yet implemented")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(statusCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/ThomasK33/vp
+
+go 1.26.2
+
+require github.com/spf13/cobra v1.10.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,0 +1,2 @@
+// Package config loads vp.yaml and resolves affected components.
+package config

--- a/internal/git/doc.go
+++ b/internal/git/doc.go
@@ -1,0 +1,2 @@
+// Package git wraps git diff for change detection.
+package git

--- a/internal/output/doc.go
+++ b/internal/output/doc.go
@@ -1,0 +1,2 @@
+// Package output formats command output as plain text or JSON.
+package output

--- a/internal/plan/doc.go
+++ b/internal/plan/doc.go
@@ -1,0 +1,2 @@
+// Package plan loads, resolves, and writes plan files under .version-plans/.
+package plan

--- a/internal/semver/doc.go
+++ b/internal/semver/doc.go
@@ -1,0 +1,2 @@
+// Package semver wraps Masterminds/semver/v3 with bump and collapse helpers.
+package semver

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,8 @@
+// Package version exposes the vp binary's version string.
+//
+// Version is a var (not a const) so that release builds can override it via
+// `-ldflags "-X github.com/ThomasK33/vp/internal/version.Version=..."`.
+package version
+
+// Version is the vp binary's version string. Release builds override it via ldflags.
+var Version = "0.1.0"

--- a/internal/versionfile/doc.go
+++ b/internal/versionfile/doc.go
@@ -1,0 +1,2 @@
+// Package versionfile reads and surgically writes version files (json, yaml, toml, text).
+package versionfile

--- a/main.go
+++ b/main.go
@@ -1,0 +1,12 @@
+// Command vp stages semver bump intent in Git.
+package main
+
+import (
+	"os"
+
+	"github.com/ThomasK33/vp/cmd"
+)
+
+func main() {
+	os.Exit(cmd.Execute())
+}

--- a/mise.lock
+++ b/mise.lock
@@ -31,3 +31,11 @@ url = "https://dl.google.com/go/go1.26.2.darwin-amd64.tar.gz"
 [tools.go."platforms.windows-x64"]
 checksum = "sha256:98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b708"
 url = "https://dl.google.com/go/go1.26.2.windows-amd64.zip"
+
+[[tools.golangci-lint]]
+version = "2.12.1"
+backend = "aqua:golangci/golangci-lint"
+
+[[tools.goreleaser]]
+version = "2.15.4"
+backend = "aqua:goreleaser/goreleaser"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,4 @@
 [tools]
 go = "1.26.2"
+golangci-lint = "2.12.1"
+goreleaser = "2.15.4"


### PR DESCRIPTION
## Summary

- Initializes the Go module at `github.com/ThomasK33/vp` with five Cobra subcommand stubs (`init`, `add`, `status`, `check`, `apply`) that return exit code **3** (runtime error per the PRD scheme).
- Pins toolchain via mise: `go 1.26.2`, `golangci-lint 2.12.1`, `goreleaser 2.15.4`.
- Adds `test.yml` (push + PR: gofmt, vet, test, golangci-lint via `jdx/mise-action@v4`) and `release.yml` (`v*` tag → cross-platform GoReleaser build, 3 OS × 2 arch).
- Lays out `internal/{semver,plan,config,versionfile,git,output}/` with `doc.go` placeholders, plus `internal/version/version.go` holding the `Version` var (overridable by GoReleaser `-ldflags` — verified via local snapshot build).
- Adds MIT `LICENSE`, stub `README.md`, and `.gitignore`.

### Notable design calls

- **Version constant lives in `internal/version`** rather than `package main`. Slight deviation from the PRD wording ("hand-rolled `version.go` constant") — chosen for a cleaner ldflags target and to let `cmd/root.go` read it without an import cycle.
- **Stub exit code is 3**, not Cobra's default 1, so the PRD's exit-code convention (`0` success / `1` check failure / `2` usage / `3` runtime) is established from day one.
- **CI relies on `jdx/mise-action@v4`'s built-in `mise install`** rather than a redundant explicit step.

Implements #2.

## Test plan

- [x] `mise install` provisions go, golangci-lint, goreleaser
- [x] `go run . --help` lists all five subcommands
- [x] Built binary's `vp init` exits **3** with `Error: not yet implemented` on stderr
- [x] `go vet ./...`, `go test ./...`, `gofmt -l .`, `golangci-lint run` all clean
- [x] `goreleaser release --snapshot --clean` produces 6 archives + `checksums.txt`; binary `--version` reflects ldflags-injected snapshot string
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)