### PR TITLE
Slice 2: vp init + config layer with upward search

### DIFF
--- a/cmd/exitcode.go
+++ b/cmd/exitcode.go
@@ -1,0 +1,19 @@
+package cmd
+
+// exitCodeError lets a command handler attach a specific process exit code
+// to the error it returns from RunE. Execute() unwraps it via errors.As.
+//
+// Use the helpers below rather than constructing the struct directly.
+type exitCodeError struct {
+	code int
+	err  error
+}
+
+func (e *exitCodeError) Error() string { return e.err.Error() }
+
+func (e *exitCodeError) Unwrap() error { return e.err }
+
+// usageError wraps err so Execute() exits with the usage/config exit code (2).
+func usageError(err error) error {
+	return &exitCodeError{code: exitUsageError, err: err}
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,18 +2,44 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
+
+	"github.com/ThomasK33/vp/internal/config"
 )
 
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Write a starter vp.yaml.",
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return errors.New("not yet implemented")
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			return err
+		}
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		if !force {
+			if existing, err := config.FindUpwards(cwd); err == nil {
+				return usageError(fmt.Errorf("vp.yaml already exists at %s; pass --force to overwrite", existing))
+			} else if !errors.Is(err, config.ErrNotFound) {
+				return err
+			}
+		}
+		target := filepath.Join(cwd, config.Filename)
+		if err := os.WriteFile(target, config.Starter(), 0o644); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s\n", target)
+		return nil
 	},
 }
 
 func init() {
+	initCmd.Flags().Bool("force", false, "overwrite an existing vp.yaml in the current directory")
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ThomasK33/vp/internal/config"
+)
+
+// runVP executes the root command with the given args inside the current
+// working directory, returning stdout/stderr buffers and the error returned
+// by Cobra. It is hermetic: it snapshots and restores rootCmd's args and
+// writers around the call.
+func runVP(t *testing.T, args ...string) (*bytes.Buffer, *bytes.Buffer, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+
+	prevArgs := os.Args
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	t.Cleanup(func() {
+		os.Args = prevArgs
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+
+	err := rootCmd.Execute()
+	return &stdout, &stderr, err
+}
+
+func TestInit_RefusesWhenExistsInCWD(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	target := filepath.Join(dir, "vp.yaml")
+	original := []byte("# pre-existing\n")
+	if err := os.WriteFile(target, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := runVP(t, "init")
+	if err == nil {
+		t.Fatalf("vp init: want error, got nil")
+	}
+	if coded, ok := errors.AsType[*exitCodeError](err); !ok || coded.code != exitUsageError {
+		t.Fatalf("vp init error = %v (code want %d)", err, exitUsageError)
+	}
+
+	got, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatalf("reading vp.yaml: %v", readErr)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("vp.yaml was modified despite refusal:\nwant %q\ngot  %q", original, got)
+	}
+}
+
+func TestInit_RefusesWhenExistsInAncestor(t *testing.T) {
+	root := t.TempDir()
+	ancestorVP := filepath.Join(root, "vp.yaml")
+	if err := os.WriteFile(ancestorVP, []byte("# parent\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(root, "child")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(child)
+
+	_, _, err := runVP(t, "init")
+	if err == nil {
+		t.Fatalf("vp init: want error, got nil")
+	}
+	if coded, ok := errors.AsType[*exitCodeError](err); !ok || coded.code != exitUsageError {
+		t.Fatalf("vp init error = %v (code want %d)", err, exitUsageError)
+	}
+	if _, statErr := os.Stat(filepath.Join(child, "vp.yaml")); !os.IsNotExist(statErr) {
+		t.Fatalf("vp.yaml was created in child despite ancestor conflict")
+	}
+}
+
+func TestInit_StarterIsValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if _, _, err := runVP(t, "init"); err != nil {
+		t.Fatalf("vp init: %v", err)
+	}
+
+	if _, err := config.Load(dir); err != nil {
+		t.Fatalf("starter vp.yaml does not load cleanly: %v", err)
+	}
+}
+
+func TestInit_FirstRunWritesStarter(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if _, _, err := runVP(t, "init"); err != nil {
+		t.Fatalf("vp init: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "vp.yaml"))
+	if err != nil {
+		t.Fatalf("reading written vp.yaml: %v", err)
+	}
+	if !bytes.Equal(got, config.Starter()) {
+		t.Fatalf("vp.yaml content does not match embedded starter")
+	}
+}
+
+func TestInit_ForceOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	target := filepath.Join(dir, "vp.yaml")
+	if err := os.WriteFile(target, []byte("# stale\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := runVP(t, "init", "--force"); err != nil {
+		t.Fatalf("vp init --force: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading vp.yaml: %v", err)
+	}
+	if !bytes.Equal(got, config.Starter()) {
+		t.Fatalf("vp.yaml not overwritten with starter")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,8 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/ThomasK33/vp/internal/version"
@@ -13,7 +15,10 @@ import (
 //	1 - vp check failure (missing plans)
 //	2 - usage / config error
 //	3 - runtime error
-const exitRuntimeError = 3
+const (
+	exitUsageError   = 2
+	exitRuntimeError = 3
+)
 
 var rootCmd = &cobra.Command{
 	Use:     "vp",
@@ -26,8 +31,12 @@ var rootCmd = &cobra.Command{
 
 // Execute runs the root command and returns the process exit code.
 func Execute() int {
-	if err := rootCmd.Execute(); err != nil {
-		return exitRuntimeError
+	err := rootCmd.Execute()
+	if err == nil {
+		return 0
 	}
-	return 0
+	if coded, ok := errors.AsType[*exitCodeError](err); ok {
+		return coded.code
+	}
+	return exitRuntimeError
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/ThomasK33/vp
 
 go 1.26.2
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/spf13/cobra v1.10.2
+	go.yaml.in/yaml/v3 v3.0.4
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// Filename is the canonical name of the vp config file.
+const Filename = "vp.yaml"
+
+// ErrNotFound is returned by FindUpwards (and Load) when no vp.yaml exists in
+// startDir or any of its ancestors.
+var ErrNotFound = errors.New("vp.yaml not found")
+
+// Config is a parsed vp.yaml. After Load, all path-shaped fields
+// (Plans.Dir, Plans.ArchiveDir, Components[*].Version.File) are absolute paths
+// rooted at Dir. Components[*].Paths are kept as relative globs — they are
+// matched against repo-relative file paths by future Affected logic.
+type Config struct {
+	Plans      PlansConfig          `yaml:"plans"`
+	Components map[string]Component `yaml:"components"`
+
+	// Dir is the directory that contained the loaded vp.yaml.
+	Dir string `yaml:"-"`
+}
+
+// PlansConfig configures the plans directory and how plans are consumed.
+type PlansConfig struct {
+	Dir        string `yaml:"dir"`
+	Consumed   string `yaml:"consumed"`
+	ArchiveDir string `yaml:"archive_dir"`
+}
+
+// Component is one independently-versioned unit declared in vp.yaml.
+type Component struct {
+	Paths   []string      `yaml:"paths"`
+	Version VersionTarget `yaml:"version"`
+	Tag     string        `yaml:"tag"`
+}
+
+// VersionTarget points at the file owning a component's canonical version.
+type VersionTarget struct {
+	File   string `yaml:"file"`
+	Format string `yaml:"format"`
+	Path   string `yaml:"path"`
+}
+
+// FindUpwards searches startDir and its ancestors for a vp.yaml file, returning
+// the absolute path to the first match. ErrNotFound is returned if no ancestor
+// contains one.
+func FindUpwards(startDir string) (string, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", err
+	}
+	for {
+		candidate := filepath.Join(dir, Filename)
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", ErrNotFound
+		}
+		dir = parent
+	}
+}
+
+// Load finds vp.yaml by searching upward from startDir, parses it, validates
+// required fields, and resolves all relative paths against the directory that
+// contained the file.
+func Load(startDir string) (*Config, error) {
+	path, err := FindUpwards(startDir)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	cfg := &Config{}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	cfg.Dir = filepath.Dir(path)
+	if err := validate(cfg); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	resolvePaths(cfg)
+	return cfg, nil
+}
+
+func resolvePaths(cfg *Config) {
+	cfg.Plans.Dir = absJoin(cfg.Dir, cfg.Plans.Dir)
+	cfg.Plans.ArchiveDir = absJoin(cfg.Dir, cfg.Plans.ArchiveDir)
+	for name, comp := range cfg.Components {
+		comp.Version.File = absJoin(cfg.Dir, comp.Version.File)
+		cfg.Components[name] = comp
+	}
+}
+
+func absJoin(base, p string) string {
+	if p == "" || filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(base, p)
+}

--- a/internal/config/find_test.go
+++ b/internal/config/find_test.go
@@ -1,0 +1,55 @@
+package config_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ThomasK33/vp/internal/config"
+)
+
+func TestFindUpwards_NotFound(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := config.FindUpwards(dir)
+	if !errors.Is(err, config.ErrNotFound) {
+		t.Fatalf("FindUpwards(%q) error = %v, want %v", dir, err, config.ErrNotFound)
+	}
+}
+
+func TestFindUpwards_InAncestor(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, "vp.yaml")
+	if err := os.WriteFile(want, []byte("plans: {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := config.FindUpwards(deep)
+	if err != nil {
+		t.Fatalf("FindUpwards: %v", err)
+	}
+	if got != want {
+		t.Fatalf("FindUpwards = %q, want %q", got, want)
+	}
+}
+
+func TestFindUpwards_InStartDir(t *testing.T) {
+	dir := t.TempDir()
+	want := filepath.Join(dir, "vp.yaml")
+	if err := os.WriteFile(want, []byte("plans: {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := config.FindUpwards(dir)
+	if err != nil {
+		t.Fatalf("FindUpwards: %v", err)
+	}
+	if got != want {
+		t.Fatalf("FindUpwards = %q, want %q", got, want)
+	}
+}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,0 +1,105 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ThomasK33/vp/internal/config"
+)
+
+const minimalValidYAML = `
+plans:
+  dir: .version-plans
+  consumed: delete
+components:
+  cli:
+    paths:
+      - "cli/**"
+    version:
+      file: "cli/package.json"
+      format: "json"
+      path: "version"
+`
+
+func writeConfig(t *testing.T, dir, contents string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoad_ParsesValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, minimalValidYAML)
+
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Dir != dir {
+		t.Errorf("Dir = %q, want %q", cfg.Dir, dir)
+	}
+	if _, ok := cfg.Components["cli"]; !ok {
+		t.Errorf("Components missing key %q (got keys %v)", "cli", keys(cfg.Components))
+	}
+	if cfg.Plans.Consumed != "delete" {
+		t.Errorf("Plans.Consumed = %q, want %q", cfg.Plans.Consumed, "delete")
+	}
+}
+
+func TestLoad_ResolvesPlansDirRelativeToConfigDir(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeConfig(t, root, `
+plans:
+  dir: .version-plans
+  consumed: archive
+  archive_dir: .version-plans/archive
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {file: cli/package.json, format: json}
+`)
+
+	cfg, err := config.Load(deep)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if want := filepath.Join(root, ".version-plans"); cfg.Plans.Dir != want {
+		t.Errorf("Plans.Dir = %q, want %q", cfg.Plans.Dir, want)
+	}
+	if want := filepath.Join(root, ".version-plans/archive"); cfg.Plans.ArchiveDir != want {
+		t.Errorf("Plans.ArchiveDir = %q, want %q", cfg.Plans.ArchiveDir, want)
+	}
+}
+
+func TestLoad_ResolvesVersionFileRelativeToConfigDir(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeConfig(t, root, minimalValidYAML)
+
+	cfg, err := config.Load(deep)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	cli := cfg.Components["cli"]
+	want := filepath.Join(root, "cli/package.json")
+	if cli.Version.File != want {
+		t.Errorf("cli.version.file = %q, want %q", cli.Version.File, want)
+	}
+}
+
+func keys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/config/starter.go
+++ b/internal/config/starter.go
@@ -1,0 +1,9 @@
+package config
+
+import _ "embed"
+
+//go:embed starter.yaml
+var starter []byte
+
+// Starter returns the bytes of the starter vp.yaml that `vp init` writes.
+func Starter() []byte { return starter }

--- a/internal/config/starter.yaml
+++ b/internal/config/starter.yaml
@@ -1,0 +1,36 @@
+# vp.yaml — declares independently-versioned components and how vp manages plans.
+# All paths are interpreted relative to the directory containing this file.
+
+plans:
+  # Directory where pending plan files live.
+  dir: .version-plans
+
+  # What vp apply does to a plan after consuming it.
+  # One of: delete | archive
+  consumed: delete
+
+  # Where consumed plans are moved when consumed = archive. Required in that case.
+  # archive_dir: .version-plans/archive
+
+components:
+  # Each key under components is a component name. Use it in plan files
+  # (e.g. `releases: { cli: minor }`) and as the {component} reference in CI.
+  cli:
+    # Glob patterns matched against repo-relative paths from `git diff`.
+    # Doublestar (**) is supported. A file matching any glob marks the
+    # component as affected.
+    paths:
+      - "cli/**"
+      - "cmd/cli/**"
+
+    # The single file owning this component's canonical version string.
+    version:
+      file: "cli/package.json"
+      # One of: json | yaml | toml | text
+      format: "json"
+      # Dotted accessor inside the file. Ignored for the text format.
+      path: "version"
+
+    # Optional. Printed by `vp apply --dry-run` so CI can pipe it to `git tag`.
+    # Single {version} placeholder; not Go-template syntax.
+    tag: "cli-v{version}"

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,55 @@
+package config
+
+import "fmt"
+
+// Allowed values for plans.consumed.
+const (
+	ConsumedDelete  = "delete"
+	ConsumedArchive = "archive"
+)
+
+// Allowed values for components[*].version.format.
+const (
+	FormatJSON = "json"
+	FormatYAML = "yaml"
+	FormatTOML = "toml"
+	FormatText = "text"
+)
+
+// validate enforces the rules from the PRD acceptance criteria. It mutates cfg
+// only to apply defaults (plans.consumed defaults to "delete" when blank).
+func validate(cfg *Config) error {
+	if cfg.Plans.Consumed == "" {
+		cfg.Plans.Consumed = ConsumedDelete
+	}
+	switch cfg.Plans.Consumed {
+	case ConsumedDelete, ConsumedArchive:
+	default:
+		return fmt.Errorf("plans.consumed: %q is not one of [%s, %s]",
+			cfg.Plans.Consumed, ConsumedDelete, ConsumedArchive)
+	}
+	if cfg.Plans.Consumed == ConsumedArchive && cfg.Plans.ArchiveDir == "" {
+		return fmt.Errorf("plans.archive_dir: required when plans.consumed is %q", ConsumedArchive)
+	}
+	if len(cfg.Components) == 0 {
+		return fmt.Errorf("components: at least one component must be declared")
+	}
+	for name, comp := range cfg.Components {
+		if len(comp.Paths) == 0 {
+			return fmt.Errorf("components.%s.paths: at least one path glob is required", name)
+		}
+		if comp.Version.File == "" {
+			return fmt.Errorf("components.%s.version.file: required", name)
+		}
+		if comp.Version.Format == "" {
+			return fmt.Errorf("components.%s.version.format: required", name)
+		}
+		switch comp.Version.Format {
+		case FormatJSON, FormatYAML, FormatTOML, FormatText:
+		default:
+			return fmt.Errorf("components.%s.version.format: %q is not one of [%s, %s, %s, %s]",
+				name, comp.Version.Format, FormatJSON, FormatYAML, FormatTOML, FormatText)
+		}
+	}
+	return nil
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,112 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ThomasK33/vp/internal/config"
+)
+
+// loadString writes contents to vp.yaml in a t.TempDir() and returns the result
+// of config.Load.
+func loadString(t *testing.T, contents string) (*config.Config, error) {
+	t.Helper()
+	dir := t.TempDir()
+	writeConfig(t, dir, contents)
+	return config.Load(dir)
+}
+
+func TestLoad_ValidationErrors(t *testing.T) {
+	cases := []struct {
+		name     string
+		yaml     string
+		wantSubs string // substring expected in the error message
+	}{
+		{
+			name: "unknown plans.consumed",
+			yaml: `
+plans:
+  consumed: yeet
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {file: cli/package.json, format: json}
+`,
+			wantSubs: "plans.consumed",
+		},
+		{
+			name: "archive without archive_dir",
+			yaml: `
+plans:
+  consumed: archive
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {file: cli/package.json, format: json}
+`,
+			wantSubs: "archive_dir",
+		},
+		{
+			name: "empty components",
+			yaml: `
+plans: {consumed: delete}
+components: {}
+`,
+			wantSubs: "components",
+		},
+		{
+			name: "component without paths",
+			yaml: `
+plans: {consumed: delete}
+components:
+  cli:
+    version: {file: cli/package.json, format: json}
+`,
+			wantSubs: "paths",
+		},
+		{
+			name: "missing version.file",
+			yaml: `
+plans: {consumed: delete}
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {format: json}
+`,
+			wantSubs: "version.file",
+		},
+		{
+			name: "missing version.format",
+			yaml: `
+plans: {consumed: delete}
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {file: cli/package.json}
+`,
+			wantSubs: "version.format",
+		},
+		{
+			name: "unknown version.format",
+			yaml: `
+plans: {consumed: delete}
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {file: cli/package.json, format: ini}
+`,
+			wantSubs: "version.format",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := loadString(t, tc.yaml)
+			if err == nil {
+				t.Fatalf("Load: want error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantSubs) {
+				t.Errorf("error %q does not contain %q", err, tc.wantSubs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #3.

## Summary

- `internal/config`: schema types, `FindUpwards` (climbs to filesystem root), `Load` (parses + validates + resolves all relative paths against the config file's directory), and `Starter()` exposing the embedded starter `vp.yaml`.
- `cmd/init`: writes a commented starter `vp.yaml` to CWD; refuses (exit 2) when a `vp.yaml` already exists in CWD or any ancestor; `--force` overwrites in CWD only.
- `cmd/exitcode.go` + `cmd/root.go`: typed `exitCodeError` so handlers can request specific exit codes (2 for usage/config errors). Reused by all future commands.

Built test-first across 18 RED → GREEN cycles (one behavior per cycle); validation rules collapsed into a table-driven test in the refactor pass.

Acceptance criteria (from #3):

- [x] `Load` searches upward from CWD until `vp.yaml` is found or filesystem root is hit; returns parsed `Config` with `Dir` set.
- [x] All paths in the resolved config are absolute, anchored at the config file's directory.
- [x] Validation: `plans.consumed` ∈ {`delete`, `archive`}; `archive_dir` required when archive; non-empty components; ≥1 path glob per component; `version.file` and `version.format` required (format ∈ {json, yaml, toml, text}).
- [x] `vp init` writes a starter `vp.yaml` with one example component and inline comments.
- [x] Exits 2 if `vp.yaml` already exists in CWD or any ancestor without `--force`.
- [x] `vp init --force` overwrites in the current directory.
- [x] Tests: table-driven `internal/config` tests for valid/invalid configs and upward-search behaviour; e2e `vp init` tests in `t.TempDir()` covering first-run, refusal, force, and ancestor-conflict.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -d .` clean
- [x] `golangci-lint run` clean
- [x] Manual smoke: `vp init` (exit 0) → `vp init` (exit 2) → `vp init --force` (exit 0) → `vp init` from child dir (exit 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)