### PR TITLE
Slice 3: vp add + internal/plan (single + multi-component plans)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -2,18 +2,90 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/ThomasK33/vp/internal/config"
+	"github.com/ThomasK33/vp/internal/plan"
 )
 
 var addCmd = &cobra.Command{
-	Use:   "add <component> <bump>",
+	Use:   "add <component> <bump>  |  add <component>=<bump> ...",
 	Short: "Add a plan file declaring component bumps.",
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return errors.New("not yet implemented")
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		cfg, err := config.Load(cwd)
+		if err != nil {
+			if errors.Is(err, config.ErrNotFound) {
+				return usageError(err)
+			}
+			return err
+		}
+
+		releases, err := parseAddArgs(args)
+		if err != nil {
+			return usageError(err)
+		}
+		for name := range releases {
+			if _, ok := cfg.Components[name]; !ok {
+				return usageError(fmt.Errorf("unknown component %q", name))
+			}
+		}
+
+		message, err := cmd.Flags().GetString("message")
+		if err != nil {
+			return err
+		}
+
+		p, err := plan.New(releases, message)
+		if err != nil {
+			return usageError(err)
+		}
+
+		if err := os.MkdirAll(cfg.Plans.Dir, 0o755); err != nil {
+			return err
+		}
+		target := filepath.Join(cfg.Plans.Dir, plan.Filename(p, time.Now().UTC()))
+		if err := plan.Save(p, target); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s\n", target)
+		return nil
 	},
 }
 
+// parseAddArgs accepts either a single bare pair (`cli minor`) or any number
+// of `key=value` pairs. Any other shape is a usage error.
+func parseAddArgs(args []string) (map[string]string, error) {
+	if len(args) == 0 {
+		return nil, errors.New("expected <component> <bump>, or one or more <component>=<bump> pairs")
+	}
+	if len(args) == 2 && !strings.Contains(args[0], "=") && !strings.Contains(args[1], "=") {
+		return map[string]string{args[0]: args[1]}, nil
+	}
+	releases := make(map[string]string, len(args))
+	for _, raw := range args {
+		k, v, ok := strings.Cut(raw, "=")
+		if !ok {
+			return nil, fmt.Errorf("expected <component>=<bump>, got %q", raw)
+		}
+		if _, dup := releases[k]; dup {
+			return nil, fmt.Errorf("component %q appears more than once", k)
+		}
+		releases[k] = v
+	}
+	return releases, nil
+}
+
 func init() {
+	addCmd.Flags().StringP("message", "m", "", "human-readable message stored in the plan")
 	rootCmd.AddCommand(addCmd)
 }

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ThomasK33/vp/internal/plan"
+)
+
+const addTestConfig = `
+plans:
+  dir: .version-plans
+  consumed: delete
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {file: cli/package.json, format: json}
+  agent:
+    paths: ["agent/**"]
+    version: {file: agent/Cargo.toml, format: toml, path: package.version}
+`
+
+// writeAddConfig writes a minimal vp.yaml declaring cli and agent components.
+func writeAddConfig(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(addTestConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// onePlanFile returns the single .yaml plan file in plansDir, failing otherwise.
+func onePlanFile(t *testing.T, plansDir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(plansDir)
+	if err != nil {
+		t.Fatalf("read plans dir: %v", err)
+	}
+	var planFile string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".yaml") {
+			if planFile != "" {
+				t.Fatalf("expected exactly one plan file, got at least 2: %s, %s", planFile, e.Name())
+			}
+			planFile = e.Name()
+		}
+	}
+	if planFile == "" {
+		t.Fatal("no plan files found")
+	}
+	return filepath.Join(plansDir, planFile)
+}
+
+func TestAdd_RequiresConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	// no vp.yaml
+
+	_, _, err := runVP(t, "add", "cli", "minor")
+	if err == nil {
+		t.Fatal("vp add: want error, got nil")
+	}
+	if coded, ok := errors.AsType[*exitCodeError](err); !ok || coded.code != exitUsageError {
+		t.Fatalf("vp add error = %v (code want %d)", err, exitUsageError)
+	}
+}
+
+// assertUsageError checks runVP returned a usage-coded error.
+func assertUsageError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	coded, ok := errors.AsType[*exitCodeError](err)
+	if !ok || coded.code != exitUsageError {
+		t.Fatalf("error = %v (code want %d)", err, exitUsageError)
+	}
+}
+
+func TestAdd_RejectsUnknownComponent(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeAddConfig(t, dir)
+
+	_, _, err := runVP(t, "add", "nope", "minor")
+	assertUsageError(t, err)
+}
+
+func TestAdd_RejectsUnknownBump(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeAddConfig(t, dir)
+
+	_, _, err := runVP(t, "add", "cli", "foo")
+	assertUsageError(t, err)
+}
+
+func TestAdd_RejectsDuplicateComponent(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeAddConfig(t, dir)
+
+	_, _, err := runVP(t, "add", "cli=minor", "cli=patch")
+	assertUsageError(t, err)
+}
+
+func TestAdd_RejectsMixedArgForms(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeAddConfig(t, dir)
+
+	_, _, err := runVP(t, "add", "cli", "minor=patch")
+	assertUsageError(t, err)
+}
+
+func TestAdd_RejectsThreeBareArgs(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeAddConfig(t, dir)
+
+	_, _, err := runVP(t, "add", "cli", "minor", "patch")
+	assertUsageError(t, err)
+}
+
+func TestAdd_RejectsEmptyKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeAddConfig(t, dir)
+
+	_, _, err := runVP(t, "add", "=minor")
+	assertUsageError(t, err)
+}
+
+func TestAdd_RejectsEmptyValue(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeAddConfig(t, dir)
+
+	_, _, err := runVP(t, "add", "cli=")
+	assertUsageError(t, err)
+}
+
+func TestAdd_FromSubdirectoryWritesAtConfigRoot(t *testing.T) {
+	root := t.TempDir()
+	writeAddConfig(t, root)
+	sub := filepath.Join(root, "sub", "deeper")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(sub)
+
+	if _, _, err := runVP(t, "add", "cli", "minor"); err != nil {
+		t.Fatalf("vp add: %v", err)
+	}
+
+	planFile := onePlanFile(t, filepath.Join(root, ".version-plans"))
+	if _, err := os.Stat(planFile); err != nil {
+		t.Fatalf("plan file not at config root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sub, ".version-plans")); !os.IsNotExist(err) {
+		t.Errorf("plans dir created in subdir, want only at config root")
+	}
+}
+
+func TestAdd_FallsBackToComponentsSlugWhenNoMessage(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeAddConfig(t, dir)
+
+	if _, _, err := runVP(t, "add", "cli=minor", "agent=patch"); err != nil {
+		t.Fatalf("vp add: %v", err)
+	}
+
+	planFile := onePlanFile(t, filepath.Join(dir, ".version-plans"))
+	if !strings.HasSuffix(filepath.Base(planFile), "-add-agent-cli.yaml") {
+		t.Errorf("plan filename = %q, want suffix -add-agent-cli.yaml", filepath.Base(planFile))
+	}
+}
+
+func TestAdd_RefusesSameDayOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeAddConfig(t, dir)
+
+	if _, _, err := runVP(t, "add", "cli", "minor"); err != nil {
+		t.Fatalf("first vp add: %v", err)
+	}
+	planFile := onePlanFile(t, filepath.Join(dir, ".version-plans"))
+	originalBytes, err := os.ReadFile(planFile)
+	if err != nil {
+		t.Fatalf("read original: %v", err)
+	}
+
+	_, _, err = runVP(t, "add", "cli", "minor")
+	if err == nil {
+		t.Fatal("second vp add: want error, got nil")
+	}
+
+	got, err := os.ReadFile(planFile)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if string(got) != string(originalBytes) {
+		t.Errorf("plan file modified by failed second add")
+	}
+}
+
+func TestAdd_KeyValueMultiWithMessage(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeAddConfig(t, dir)
+
+	if _, _, err := runVP(t, "add", "cli=minor", "agent=patch", "-m", "Fix reconnect"); err != nil {
+		t.Fatalf("vp add: %v", err)
+	}
+
+	planFile := onePlanFile(t, filepath.Join(dir, ".version-plans"))
+	if !strings.HasSuffix(planFile, "-fix-reconnect.yaml") {
+		t.Errorf("plan filename = %q, want suffix -fix-reconnect.yaml", filepath.Base(planFile))
+	}
+	p, err := plan.Load(planFile)
+	if err != nil {
+		t.Fatalf("plan.Load: %v", err)
+	}
+	if got, want := p.Releases["cli"], "minor"; got != want {
+		t.Errorf("Releases[cli] = %q, want %q", got, want)
+	}
+	if got, want := p.Releases["agent"], "patch"; got != want {
+		t.Errorf("Releases[agent] = %q, want %q", got, want)
+	}
+	if got, want := p.Message, "Fix reconnect"; got != want {
+		t.Errorf("Message = %q, want %q", got, want)
+	}
+}
+
+func TestAdd_BareSinglePair(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeAddConfig(t, dir)
+
+	if _, _, err := runVP(t, "add", "cli", "minor"); err != nil {
+		t.Fatalf("vp add cli minor: %v", err)
+	}
+
+	planFile := onePlanFile(t, filepath.Join(dir, ".version-plans"))
+	p, err := plan.Load(planFile)
+	if err != nil {
+		t.Fatalf("plan.Load: %v", err)
+	}
+	if got, want := p.Releases["cli"], "minor"; got != want {
+		t.Errorf("Releases[cli] = %q, want %q", got, want)
+	}
+	if len(p.Releases) != 1 {
+		t.Errorf("Releases = %v, want exactly 1 entry", p.Releases)
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -19,6 +19,9 @@ const (
 // validate enforces the rules from the PRD acceptance criteria. It mutates cfg
 // only to apply defaults (plans.consumed defaults to "delete" when blank).
 func validate(cfg *Config) error {
+	if cfg.Plans.Dir == "" {
+		return fmt.Errorf("plans.dir: required")
+	}
 	if cfg.Plans.Consumed == "" {
 		cfg.Plans.Consumed = ConsumedDelete
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -26,6 +26,7 @@ func TestLoad_ValidationErrors(t *testing.T) {
 			name: "unknown plans.consumed",
 			yaml: `
 plans:
+  dir: .version-plans
   consumed: yeet
 components:
   cli:
@@ -35,9 +36,22 @@ components:
 			wantSubs: "plans.consumed",
 		},
 		{
+			name: "missing plans.dir",
+			yaml: `
+plans:
+  consumed: delete
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {file: cli/package.json, format: json}
+`,
+			wantSubs: "plans.dir",
+		},
+		{
 			name: "archive without archive_dir",
 			yaml: `
 plans:
+  dir: .version-plans
   consumed: archive
 components:
   cli:
@@ -49,7 +63,7 @@ components:
 		{
 			name: "empty components",
 			yaml: `
-plans: {consumed: delete}
+plans: {dir: .version-plans, consumed: delete}
 components: {}
 `,
 			wantSubs: "components",
@@ -57,7 +71,7 @@ components: {}
 		{
 			name: "component without paths",
 			yaml: `
-plans: {consumed: delete}
+plans: {dir: .version-plans, consumed: delete}
 components:
   cli:
     version: {file: cli/package.json, format: json}
@@ -67,7 +81,7 @@ components:
 		{
 			name: "missing version.file",
 			yaml: `
-plans: {consumed: delete}
+plans: {dir: .version-plans, consumed: delete}
 components:
   cli:
     paths: ["cli/**"]
@@ -78,7 +92,7 @@ components:
 		{
 			name: "missing version.format",
 			yaml: `
-plans: {consumed: delete}
+plans: {dir: .version-plans, consumed: delete}
 components:
   cli:
     paths: ["cli/**"]
@@ -89,7 +103,7 @@ components:
 		{
 			name: "unknown version.format",
 			yaml: `
-plans: {consumed: delete}
+plans: {dir: .version-plans, consumed: delete}
 components:
   cli:
     paths: ["cli/**"]
@@ -104,8 +118,15 @@ components:
 			if err == nil {
 				t.Fatalf("Load: want error, got nil")
 			}
-			if !strings.Contains(err.Error(), tc.wantSubs) {
-				t.Errorf("error %q does not contain %q", err, tc.wantSubs)
+			// Strip the "<path>: " prefix that Load adds. The path may contain
+			// the subtest name (which includes the substring being matched), so
+			// matching against the unwrapped error is the only honest check.
+			msg := err.Error()
+			if i := strings.Index(msg, "vp.yaml: "); i >= 0 {
+				msg = msg[i+len("vp.yaml: "):]
+			}
+			if !strings.Contains(msg, tc.wantSubs) {
+				t.Errorf("error %q does not contain %q", msg, tc.wantSubs)
 			}
 		})
 	}

--- a/internal/plan/filename.go
+++ b/internal/plan/filename.go
@@ -1,0 +1,68 @@
+package plan
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// slugMaxLen caps the message-derived slug length. Longer slugs are truncated
+// at a word boundary.
+const slugMaxLen = 50
+
+// Filename returns "YYYY-MM-DD-<slug>.yaml" using when.UTC() for the date.
+// The slug is derived from p.Message, falling back to "add-<sorted-components>"
+// when the message is empty or sanitises to nothing.
+func Filename(p *Plan, when time.Time) string {
+	slug := truncateSlug(slugFromMessage(p.Message), slugMaxLen)
+	if slug == "" {
+		slug = "add-" + sortedComponentSlug(p.Releases)
+	}
+	return when.UTC().Format("2006-01-02") + "-" + slug + ".yaml"
+}
+
+// slugFromMessage lowercases s and collapses runs of non-alphanumeric runes
+// into single hyphens. Returns "" if s contains no alphanumeric runes.
+func slugFromMessage(s string) string {
+	var b strings.Builder
+	prevDash := true
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// truncateSlug shortens slug to at most maxLen chars, ending on a word
+// boundary. Words are dash-separated. If the first word alone exceeds maxLen,
+// the slug is returned unchanged (better a long filename than a half-word).
+func truncateSlug(slug string, maxLen int) string {
+	if len(slug) <= maxLen {
+		return slug
+	}
+	cut := strings.LastIndex(slug[:maxLen+1], "-")
+	if cut <= 0 {
+		return slug
+	}
+	return slug[:cut]
+}
+
+// sortedComponentSlug joins component names with "-" in sorted order.
+// Component names are passed through slugFromMessage to ensure the result is
+// safe (and to collapse any internal whitespace).
+func sortedComponentSlug(releases map[string]string) string {
+	names := make([]string, 0, len(releases))
+	for name := range releases {
+		names = append(names, slugFromMessage(name))
+	}
+	sort.Strings(names)
+	return strings.Join(names, "-")
+}

--- a/internal/plan/filename_test.go
+++ b/internal/plan/filename_test.go
@@ -1,0 +1,104 @@
+package plan_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ThomasK33/vp/internal/plan"
+)
+
+func TestFilename_FallsBackWhenNoMessage(t *testing.T) {
+	when := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	p, err := plan.New(map[string]string{"cli": "minor", "agent": "patch"}, "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := plan.Filename(p, when)
+	want := "2026-05-03-add-agent-cli.yaml"
+	if got != want {
+		t.Errorf("Filename = %q, want %q", got, want)
+	}
+}
+
+func TestFilename_FallsBackWhenSlugSanitisesEmpty(t *testing.T) {
+	when := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	p, err := plan.New(map[string]string{"cli": "minor"}, "!!! ???")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := plan.Filename(p, when)
+	want := "2026-05-03-add-cli.yaml"
+	if got != want {
+		t.Errorf("Filename = %q, want %q", got, want)
+	}
+}
+
+func TestFilename_TruncatesLongSlugAtWordBoundary(t *testing.T) {
+	when := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	p, err := plan.New(
+		map[string]string{"cli": "minor"},
+		"This is a fairly long message that should be truncated cleanly at a word boundary",
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := plan.Filename(p, when)
+	const datePrefix = "2026-05-03-"
+	const ext = ".yaml"
+	if !strings.HasPrefix(got, datePrefix) || !strings.HasSuffix(got, ext) {
+		t.Fatalf("Filename = %q, want %s<slug>%s", got, datePrefix, ext)
+	}
+	slug := strings.TrimSuffix(strings.TrimPrefix(got, datePrefix), ext)
+	if len(slug) > 50 {
+		t.Errorf("slug %q exceeds 50 chars (len=%d)", slug, len(slug))
+	}
+	if strings.HasSuffix(slug, "-") || strings.HasPrefix(slug, "-") {
+		t.Errorf("slug %q has leading/trailing dash", slug)
+	}
+	// Truncation must happen on a word boundary: the slug must be a prefix
+	// of the fully-slugified message split on dashes.
+	full := "this-is-a-fairly-long-message-that-should-be-truncated-cleanly-at-a-word-boundary"
+	if !strings.HasPrefix(full, slug) {
+		t.Errorf("slug %q is not a word-boundary prefix of %q", slug, full)
+	}
+	for word := range strings.SplitSeq(slug, "-") {
+		if word == "" {
+			t.Errorf("slug %q contains empty word (mid-word truncation)", slug)
+		}
+	}
+}
+
+func TestFilename_HyphenatedComponentNamesNoDoubleDash(t *testing.T) {
+	when := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	p, err := plan.New(map[string]string{"web-app": "minor", "cli": "patch"}, "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := plan.Filename(p, when)
+	if strings.Contains(got, "--") {
+		t.Errorf("Filename %q contains a double-dash", got)
+	}
+	want := "2026-05-03-add-cli-web-app.yaml"
+	if got != want {
+		t.Errorf("Filename = %q, want %q", got, want)
+	}
+}
+
+func TestFilename_UsesUTCDate(t *testing.T) {
+	// 2026-05-03 23:30 in a +05:00 zone is 2026-05-03 18:30 UTC.
+	// Confirms the date in the filename is computed in UTC, not local time.
+	zone := time.FixedZone("test", 5*60*60)
+	when := time.Date(2026, 5, 4, 2, 30, 0, 0, zone) // 2026-05-03 21:30 UTC
+
+	p, err := plan.New(map[string]string{"cli": "minor"}, "Fix reconnect")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	got := plan.Filename(p, when)
+	want := "2026-05-03-fix-reconnect.yaml"
+	if got != want {
+		t.Errorf("Filename = %q, want %q", got, want)
+	}
+}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -1,0 +1,87 @@
+package plan
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// Plan is the in-memory representation of a .version-plans/*.yaml file.
+type Plan struct {
+	Releases map[string]string `yaml:"releases"`
+	Message  string            `yaml:"message,omitempty"`
+}
+
+// Bump levels.
+const (
+	BumpMajor = "major"
+	BumpMinor = "minor"
+	BumpPatch = "patch"
+	BumpNone  = "none"
+)
+
+func validBump(b string) bool {
+	switch b {
+	case BumpMajor, BumpMinor, BumpPatch, BumpNone:
+		return true
+	}
+	return false
+}
+
+// New constructs and validates a Plan from the given releases and message.
+func New(releases map[string]string, message string) (*Plan, error) {
+	if len(releases) == 0 {
+		return nil, fmt.Errorf("releases: at least one component bump is required")
+	}
+	for name, bump := range releases {
+		if name == "" {
+			return nil, fmt.Errorf("releases: component name must be non-empty")
+		}
+		if bump == "" {
+			return nil, fmt.Errorf("releases.%s: bump must be non-empty", name)
+		}
+		if !validBump(bump) {
+			return nil, fmt.Errorf("releases.%s: %q is not one of [%s, %s, %s, %s]",
+				name, bump, BumpMajor, BumpMinor, BumpPatch, BumpNone)
+		}
+	}
+	return &Plan{Releases: releases, Message: message}, nil
+}
+
+// Save writes p to path as YAML with 2-space indent. It refuses to overwrite
+// an existing file. Callers must ensure the parent directory exists.
+func Save(p *Plan, path string) error {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(p); err != nil {
+		return fmt.Errorf("encode plan: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("encode plan: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// Load parses a plan file at path.
+func Load(path string) (*Plan, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	p := &Plan{}
+	if err := yaml.Unmarshal(data, p); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return p, nil
+}

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1,0 +1,108 @@
+package plan_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/ThomasK33/vp/internal/plan"
+)
+
+func TestNew_RejectsEmptyReleases(t *testing.T) {
+	if _, err := plan.New(map[string]string{}, ""); err == nil {
+		t.Fatal("New: want error for empty releases, got nil")
+	}
+	if _, err := plan.New(nil, ""); err == nil {
+		t.Fatal("New: want error for nil releases, got nil")
+	}
+}
+
+func TestNew_RejectsEmptyComponentName(t *testing.T) {
+	_, err := plan.New(map[string]string{"": "minor"}, "")
+	if err == nil {
+		t.Fatal("New: want error for empty component name, got nil")
+	}
+}
+
+func TestNew_RejectsEmptyBump(t *testing.T) {
+	_, err := plan.New(map[string]string{"cli": ""}, "")
+	if err == nil {
+		t.Fatal("New: want error for empty bump, got nil")
+	}
+}
+
+func TestNew_RejectsUnknownBump(t *testing.T) {
+	_, err := plan.New(map[string]string{"cli": "huge"}, "")
+	if err == nil {
+		t.Fatal("New: want error for unknown bump, got nil")
+	}
+}
+
+func TestNew_AcceptsAllBumps(t *testing.T) {
+	for _, bump := range []string{"major", "minor", "patch", "none"} {
+		if _, err := plan.New(map[string]string{"cli": bump}, ""); err != nil {
+			t.Errorf("New(cli=%s): unexpected error: %v", bump, err)
+		}
+	}
+}
+
+func TestSave_RefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "2026-05-03-existing.yaml")
+
+	first, err := plan.New(map[string]string{"cli": "minor"}, "first")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := plan.Save(first, target); err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+	original, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+
+	second, err := plan.New(map[string]string{"cli": "patch"}, "second")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := plan.Save(second, target); err == nil {
+		t.Fatal("second Save: want error, got nil")
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("re-read target: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Errorf("file modified despite refusal:\nwant %q\ngot  %q", original, got)
+	}
+}
+
+func TestSaveLoadRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "2026-05-03-roundtrip.yaml")
+
+	p, err := plan.New(map[string]string{"cli": "minor", "agent": "patch"}, "Fix reconnect")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := plan.Save(p, target); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := plan.Load(target)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if !reflect.DeepEqual(got.Releases, p.Releases) {
+		t.Errorf("Releases roundtrip mismatch: got %v, want %v", got.Releases, p.Releases)
+	}
+	if got.Message != p.Message {
+		t.Errorf("Message = %q, want %q", got.Message, p.Message)
+	}
+}


### PR DESCRIPTION
Closes #4. Builds on #3 (slice 2 config layer).

## Summary
- `internal/plan`: `Plan` type + `New`/`Save`/`Load`/`Filename`. Save uses `O_CREATE|O_EXCL` to refuse overwrites. Filename derives a kebab slug from the optional message (truncated at a 50-char word boundary), falling back to `add-<sorted-components>` when no usable slug.
- `vp add`: accepts both `vp add cli minor` and `vp add cli=minor agent=patch -m "Fix reconnect"`. Validates each component against the loaded config, rejects duplicates, creates `.version-plans/` if missing, and runs from any subdirectory of the repo.
- Adjacent fix: `internal/config/validate.go` now requires `plans.dir` non-empty, preventing a confusing `os.MkdirAll("")` failure in `vp add`. Existing `validate_test.go` rows were passing for the wrong reason — `t.TempDir` paths embed the subtest name, which contained the substring being matched — so tests now strip the path prefix before matching and include `plans.dir` in fixtures.

## Test plan
- [x] `go test ./...` (15 new unit + e2e tests; existing config validation tests reworked)
- [x] `go vet ./...`
- [x] `gofmt -d ./cmd ./internal`
- [x] `golangci-lint run ./...` (0 issues)
- [x] Manual smoke: `vp init && vp add cli minor && vp add cli=minor -m "Fix reconnect handler"` writes two correctly-named YAML files; running from a subdirectory writes to the canonical `.version-plans/` at the config root; same-day overwrite is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)