### PR TITLE
Slice 5: vp apply + semver.Next + versionfile/text

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -2,18 +2,158 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+
+	"github.com/ThomasK33/vp/internal/config"
+	"github.com/ThomasK33/vp/internal/semver"
+	"github.com/ThomasK33/vp/internal/versionfile/text"
 )
+
+type plannedChange struct {
+	name    string
+	bump    semver.Bump
+	current string
+	next    string
+	file    string
+}
 
 var applyCmd = &cobra.Command{
 	Use:   "apply",
 	Short: "Collapse pending plans, update version files, and consume the plans.",
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return errors.New("not yet implemented")
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		cfg, err := config.Load(cwd)
+		if err != nil {
+			if errors.Is(err, config.ErrNotFound) {
+				return usageError(err)
+			}
+			return err
+		}
+
+		if cfg.Plans.Consumed == config.ConsumedArchive {
+			return errors.New("archive consumption mode not yet implemented (planned for a later release)")
+		}
+
+		pending, collapsed, err := resolveBumps(cfg)
+		if err != nil {
+			return err
+		}
+
+		changes, err := planChanges(cfg, collapsed)
+		if err != nil {
+			return err
+		}
+
+		dryRun, err := cmd.Flags().GetBool("dry-run")
+		if err != nil {
+			return err
+		}
+
+		out := cmd.OutOrStdout()
+		if dryRun {
+			renderDryRun(out, cfg, changes)
+			return nil
+		}
+
+		if len(changes) == 0 {
+			_, _ = fmt.Fprintln(out, "no version changes")
+		} else {
+			renderApplied(out, cfg, changes)
+		}
+
+		for _, ch := range changes {
+			if err := text.Write(ch.file, ch.next); err != nil {
+				return err
+			}
+		}
+		for _, p := range pending {
+			if err := os.Remove(p.Path); err != nil {
+				return err
+			}
+		}
+
+		_, _ = fmt.Fprintf(out, "Wrote %d file(s); consumed %d plan(s).\n", len(changes), len(pending))
+		return nil
 	},
 }
 
+// planChanges turns collapsed bumps into plannedChange entries, validating
+// component formats and version files. Components whose collapsed bump is
+// BumpNone produce no entry (no read or write needed).
+func planChanges(cfg *config.Config, collapsed map[string]semver.Bump) ([]plannedChange, error) {
+	var changes []plannedChange
+	for _, name := range sortedKeys(collapsed) {
+		level := collapsed[name]
+		if level == semver.BumpNone {
+			continue
+		}
+		comp := cfg.Components[name]
+		if comp.Version.Format != config.FormatText {
+			return nil, fmt.Errorf(
+				"component %q: version file format %q not yet supported (text only in this release)",
+				name, comp.Version.Format,
+			)
+		}
+		cur, err := text.Read(comp.Version.File)
+		if err != nil {
+			return nil, err
+		}
+		next, err := semver.Next(cur, level)
+		if err != nil {
+			return nil, fmt.Errorf("component %q: %w", name, err)
+		}
+		changes = append(changes, plannedChange{
+			name:    name,
+			bump:    level,
+			current: cur,
+			next:    next,
+			file:    comp.Version.File,
+		})
+	}
+	return changes, nil
+}
+
+func renderDryRun(out io.Writer, cfg *config.Config, changes []plannedChange) {
+	if len(changes) == 0 {
+		_, _ = fmt.Fprintln(out, "no version changes")
+		return
+	}
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "component\tcurrent\tnext\tbump\tfile")
+	for _, ch := range changes {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			ch.name, ch.current, ch.next, ch.bump, relPath(cfg.Dir, ch.file))
+	}
+	_ = tw.Flush()
+}
+
+func renderApplied(out io.Writer, cfg *config.Config, changes []plannedChange) {
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	for _, ch := range changes {
+		_, _ = fmt.Fprintf(tw, "%s\t%s -> %s\t(%s)\t%s\n",
+			ch.name, ch.current, ch.next, ch.bump, relPath(cfg.Dir, ch.file))
+	}
+	_ = tw.Flush()
+}
+
+func relPath(base, p string) string {
+	rel, err := filepath.Rel(base, p)
+	if err != nil {
+		return p
+	}
+	return rel
+}
+
 func init() {
+	applyCmd.Flags().Bool("dry-run", false, "show planned changes without writing files or consuming plans")
 	rootCmd.AddCommand(applyCmd)
 }

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1,0 +1,241 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const applyTestConfigText = `
+plans:
+  dir: .version-plans
+  consumed: delete
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {file: VERSION, format: text}
+`
+
+func writeApplyTextConfig(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(applyTestConfigText), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestApply_DryRunDoesNotTouchFilesOrPlans(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeApplyTextConfig(t, dir)
+
+	versionPath := filepath.Join(dir, "VERSION")
+	if err := os.WriteFile(versionPath, []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	planPath := filepath.Join(plansDir, "2026-05-03-bump.yaml")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "apply", "--dry-run")
+	if err != nil {
+		t.Fatalf("vp apply --dry-run: %v", err)
+	}
+
+	got, err := os.ReadFile(versionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "1.2.3\n" {
+		t.Errorf("VERSION changed during dry-run: got %q", got)
+	}
+	if _, err := os.Stat(planPath); err != nil {
+		t.Errorf("plan file removed during dry-run: %v", err)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"component", "current", "next", "bump", "file", "cli", "1.2.3", "1.3.0", "minor", "VERSION"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run stdout missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestApply_AllNoneConsumesPlansWithoutWriting(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeApplyTextConfig(t, dir)
+
+	versionPath := filepath.Join(dir, "VERSION")
+	if err := os.WriteFile(versionPath, []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-noop.yaml", "releases:\n  cli: none\n")
+
+	stdout, _, err := runVP(t, "apply")
+	if err != nil {
+		t.Fatalf("vp apply: %v", err)
+	}
+
+	got, _ := os.ReadFile(versionPath)
+	if string(got) != "1.2.3\n" {
+		t.Errorf("VERSION modified for all-none plan: got %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(plansDir, "2026-05-03-noop.yaml")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("plan file not consumed: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "no version changes") {
+		t.Errorf("stdout missing 'no version changes':\n%s", stdout.String())
+	}
+}
+
+func TestApply_RejectsArchiveConsumptionMode(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	cfg := strings.Replace(applyTestConfigText, "consumed: delete", "consumed: archive\n  archive_dir: .version-plans/archive", 1)
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	_, _, err := runVP(t, "apply")
+	if err == nil {
+		t.Fatal("vp apply: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "archive") {
+		t.Errorf("error = %v, want it to mention archive", err)
+	}
+	// Ensure no side effects.
+	got, _ := os.ReadFile(filepath.Join(dir, "VERSION"))
+	if string(got) != "1.2.3\n" {
+		t.Errorf("VERSION modified despite archive-mode rejection: %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(plansDir, "2026-05-03-bump.yaml")); err != nil {
+		t.Errorf("plan removed despite archive-mode rejection: %v", err)
+	}
+}
+
+func TestApply_UnknownComponentInPlan(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeApplyTextConfig(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-typo.yaml", "releases:\n  nope: minor\n")
+
+	_, _, err := runVP(t, "apply")
+	assertUsageError(t, err)
+	got, _ := os.ReadFile(filepath.Join(dir, "VERSION"))
+	if string(got) != "1.2.3\n" {
+		t.Errorf("VERSION modified despite Phase 1 failure: %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(plansDir, "2026-05-03-typo.yaml")); err != nil {
+		t.Errorf("plan removed despite Phase 1 failure: %v", err)
+	}
+}
+
+func TestApply_RejectsNonTextFormatWithBump(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(statusTestConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	_, _, err := runVP(t, "apply")
+	if err == nil {
+		t.Fatal("vp apply: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not yet supported") {
+		t.Errorf("error = %v, want it to mention 'not yet supported'", err)
+	}
+	if _, err := os.Stat(filepath.Join(plansDir, "2026-05-03-bump.yaml")); err != nil {
+		t.Errorf("plan removed despite Phase 1 failure: %v", err)
+	}
+}
+
+func TestApply_RejectsMissingVersionFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeApplyTextConfig(t, dir)
+	// no VERSION file written
+
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	_, _, err := runVP(t, "apply")
+	if err == nil {
+		t.Fatal("vp apply: want error, got nil")
+	}
+	if _, err := os.Stat(filepath.Join(plansDir, "2026-05-03-bump.yaml")); err != nil {
+		t.Errorf("plan removed despite Phase 1 failure: %v", err)
+	}
+}
+
+func TestApply_NonTextFormatWithAllNoneSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(statusTestConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-noop.yaml", "releases:\n  cli: none\n")
+
+	stdout, _, err := runVP(t, "apply")
+	if err != nil {
+		t.Fatalf("vp apply: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "no version changes") {
+		t.Errorf("stdout missing 'no version changes': %s", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(plansDir, "2026-05-03-noop.yaml")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("plan should have been consumed: %v", err)
+	}
+}
+
+func TestApply_HappyPathWritesAndConsumes(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeApplyTextConfig(t, dir)
+
+	versionPath := filepath.Join(dir, "VERSION")
+	if err := os.WriteFile(versionPath, []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "apply")
+	if err != nil {
+		t.Fatalf("vp apply: %v", err)
+	}
+
+	got, err := os.ReadFile(versionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "1.3.0\n" {
+		t.Errorf("VERSION after apply = %q, want %q", got, "1.3.0\n")
+	}
+
+	if _, err := os.Stat(filepath.Join(plansDir, "2026-05-03-bump.yaml")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("plan file still exists after apply: %v", err)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"cli", "1.2.3", "1.3.0", "minor"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q\n---\n%s", want, out)
+		}
+	}
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/ThomasK33/vp/internal/config"
 )
 
@@ -27,10 +30,24 @@ func runVP(t *testing.T, args ...string) (*bytes.Buffer, *bytes.Buffer, error) {
 		rootCmd.SetArgs(nil)
 		rootCmd.SetOut(nil)
 		rootCmd.SetErr(nil)
+		resetAllFlags(rootCmd)
 	})
 
 	err := rootCmd.Execute()
 	return &stdout, &stderr, err
+}
+
+// resetAllFlags walks the command tree and restores every flag to its declared
+// default. Cobra/pflag retain parsed flag values across Execute() calls on the
+// same command object, which leaks state between tests.
+func resetAllFlags(c *cobra.Command) {
+	c.Flags().VisitAll(func(f *pflag.Flag) {
+		_ = f.Value.Set(f.DefValue)
+		f.Changed = false
+	})
+	for _, sub := range c.Commands() {
+		resetAllFlags(sub)
+	}
 }
 
 func TestInit_RefusesWhenExistsInCWD(t *testing.T) {

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/ThomasK33/vp/internal/config"
+	"github.com/ThomasK33/vp/internal/plan"
+	"github.com/ThomasK33/vp/internal/semver"
+)
+
+// resolveBumps loads pending plans, validates that every release names a known
+// component and a known bump, and returns the collapsed bump per component.
+// All validation failures are wrapped as usage errors with the offending plan
+// filename in the message.
+func resolveBumps(cfg *config.Config) (pending []plan.Pending, collapsed map[string]semver.Bump, err error) {
+	pending, err = plan.LoadDir(cfg.Plans.Dir)
+	if err != nil {
+		return nil, nil, usageError(err)
+	}
+	levels := map[string][]semver.Bump{}
+	for _, p := range pending {
+		base := filepath.Base(p.Path)
+		for name, raw := range p.Plan.Releases {
+			if _, ok := cfg.Components[name]; !ok {
+				return nil, nil, usageError(fmt.Errorf("plan %s: unknown component %q", base, name))
+			}
+			b, err := semver.ParseBump(raw)
+			if err != nil {
+				return nil, nil, usageError(fmt.Errorf("plan %s: %w", base, err))
+			}
+			levels[name] = append(levels[name], b)
+		}
+	}
+	collapsed = make(map[string]semver.Bump, len(levels))
+	for name, bs := range levels {
+		collapsed[name] = semver.Collapse(bs)
+	}
+	return pending, collapsed, nil
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -11,8 +11,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ThomasK33/vp/internal/config"
-	"github.com/ThomasK33/vp/internal/plan"
 	"github.com/ThomasK33/vp/internal/semver"
+	"github.com/ThomasK33/vp/internal/versionfile/text"
 )
 
 var statusCmd = &cobra.Command{
@@ -31,9 +31,9 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 
-		pending, err := plan.LoadDir(cfg.Plans.Dir)
+		pending, collapsed, err := resolveBumps(cfg)
 		if err != nil {
-			return usageError(err)
+			return err
 		}
 
 		showAll, err := cmd.Flags().GetBool("all")
@@ -42,23 +42,6 @@ var statusCmd = &cobra.Command{
 		}
 
 		out := cmd.OutOrStdout()
-
-		// Collect bumps in a first pass so an unknown component fails before
-		// any output is written.
-		levels := map[string][]semver.Bump{}
-		for _, p := range pending {
-			base := filepath.Base(p.Path)
-			for name, raw := range p.Plan.Releases {
-				if _, ok := cfg.Components[name]; !ok {
-					return usageError(fmt.Errorf("plan %s: unknown component %q", base, name))
-				}
-				b, err := semver.ParseBump(raw)
-				if err != nil {
-					return usageError(fmt.Errorf("plan %s: %w", base, err))
-				}
-				levels[name] = append(levels[name], b)
-			}
-		}
 
 		if len(pending) == 0 {
 			_, _ = fmt.Fprintln(out, "No pending plans.")
@@ -73,21 +56,48 @@ var statusCmd = &cobra.Command{
 			_, _ = fmt.Fprintln(out)
 		}
 		if len(pending) > 0 || showAll {
-			printSummary(out, cfg, levels, showAll)
+			printSummary(out, cfg, collapsed, showAll)
 		}
 		return nil
 	},
 }
 
-func printSummary(out io.Writer, cfg *config.Config, levels map[string][]semver.Bump, showAll bool) {
-	names := sortedKeys(levels)
+func printSummary(out io.Writer, cfg *config.Config, collapsed map[string]semver.Bump, showAll bool) {
+	names := sortedKeys(collapsed)
 	if showAll {
 		names = sortedKeys(cfg.Components)
 	}
 	_, _ = fmt.Fprintln(out, "Resolved bumps:")
 	for _, n := range names {
-		_, _ = fmt.Fprintf(out, "  %s: %s\n", n, semver.Collapse(levels[n]))
+		level := collapsed[n]
+		if level == "" {
+			level = semver.BumpNone
+		}
+		_, _ = fmt.Fprintf(out, "  %s\n", formatSummaryLine(cfg, n, level))
 	}
+}
+
+// formatSummaryLine renders one resolved-bump row. For text-format components
+// it appends current/next version info; for any other format (or when reading
+// the version file fails) it falls back to the bare "name: bump" form.
+func formatSummaryLine(cfg *config.Config, name string, level semver.Bump) string {
+	bare := fmt.Sprintf("%s: %s", name, level)
+	comp, ok := cfg.Components[name]
+	if !ok || comp.Version.Format != config.FormatText {
+		return bare
+	}
+	cur, err := text.Read(comp.Version.File)
+	if err != nil {
+		return bare
+	}
+	if level == semver.BumpNone {
+		return fmt.Sprintf("%s (%s)", bare, cur)
+	}
+	next, err := semver.Next(cur, level)
+	if err != nil {
+		return bare
+	}
+	return fmt.Sprintf("%s (%s -> %s)", bare, cur, next)
 }
 
 func sortedKeys[V any](m map[string]V) []string {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -171,3 +171,106 @@ func TestStatus_ErrorsWithoutConfig(t *testing.T) {
 	_, _, err := runVP(t, "status")
 	assertUsageError(t, err)
 }
+
+const statusTextConfig = `
+plans:
+  dir: .version-plans
+  consumed: delete
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {file: VERSION, format: text}
+`
+
+func TestStatus_TextComponentShowsCurrentAndNext(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(statusTextConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "status")
+	if err != nil {
+		t.Fatalf("vp status: %v", err)
+	}
+	got := stdout.String()
+	summary := got[strings.Index(got, "Resolved bumps:"):]
+	if !strings.Contains(summary, "1.2.3") || !strings.Contains(summary, "1.3.0") {
+		t.Errorf("summary missing current/next versions:\n%s", summary)
+	}
+	if !strings.Contains(summary, "->") && !strings.Contains(summary, "→") {
+		t.Errorf("summary missing arrow between current and next:\n%s", summary)
+	}
+}
+
+func TestStatus_TextComponentNoneShowsCurrentOnly(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(statusTextConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-noop.yaml", "releases:\n  cli: none\n")
+
+	stdout, _, err := runVP(t, "status")
+	if err != nil {
+		t.Fatalf("vp status: %v", err)
+	}
+	summary := stdout.String()[strings.Index(stdout.String(), "Resolved bumps:"):]
+	if !strings.Contains(summary, "1.2.3") {
+		t.Errorf("summary missing current version: %s", summary)
+	}
+	if strings.Contains(summary, "->") || strings.Contains(summary, "→") {
+		t.Errorf("summary unexpectedly contains arrow for none bump: %s", summary)
+	}
+}
+
+func TestStatus_TextComponentMissingFileFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(statusTextConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// no VERSION file
+
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "status")
+	if err != nil {
+		t.Fatalf("vp status: %v", err)
+	}
+	summary := stdout.String()[strings.Index(stdout.String(), "Resolved bumps:"):]
+	if !strings.Contains(summary, "cli: minor") {
+		t.Errorf("summary missing fallback 'cli: minor':\n%s", summary)
+	}
+}
+
+func TestStatus_NonTextComponentUnchangedFormat(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeStatusConfig(t, dir)
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "status")
+	if err != nil {
+		t.Fatalf("vp status: %v", err)
+	}
+	summary := stdout.String()[strings.Index(stdout.String(), "Resolved bumps:"):]
+	// cli is json format here; no arrow, no current/next.
+	if strings.Contains(summary, "->") || strings.Contains(summary, "→") {
+		t.Errorf("summary unexpectedly contains arrow for non-text component:\n%s", summary)
+	}
+	if !strings.Contains(summary, "cli: minor") {
+		t.Errorf("summary missing bare 'cli: minor':\n%s", summary)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ThomasK33/vp
 go 1.26.2
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/spf13/cobra v1.10.2
 	go.yaml.in/yaml/v3 v3.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/internal/semver/next.go
+++ b/internal/semver/next.go
@@ -1,0 +1,38 @@
+package semver
+
+import (
+	"fmt"
+	"strings"
+
+	masterminds "github.com/Masterminds/semver/v3"
+)
+
+// Next returns the version string produced by applying level to version.
+// An optional leading "v" is preserved on output. For major/minor/patch bumps,
+// any prerelease and build metadata are dropped per ADR-0003. BumpNone returns
+// version unchanged after parse validation.
+func Next(version string, level Bump) (string, error) {
+	body, hadV := strings.CutPrefix(version, "v")
+	v, err := masterminds.NewVersion(body)
+	if err != nil {
+		return "", fmt.Errorf("parse version %q: %w", version, err)
+	}
+	var next masterminds.Version
+	switch level {
+	case BumpNone:
+		return version, nil
+	case BumpPatch:
+		next = v.IncPatch()
+	case BumpMinor:
+		next = v.IncMinor()
+	case BumpMajor:
+		next = v.IncMajor()
+	default:
+		return "", fmt.Errorf("unknown bump %q", level)
+	}
+	out := next.String()
+	if hadV {
+		out = "v" + out
+	}
+	return out, nil
+}

--- a/internal/semver/next_test.go
+++ b/internal/semver/next_test.go
@@ -1,0 +1,46 @@
+package semver_test
+
+import (
+	"testing"
+
+	"github.com/ThomasK33/vp/internal/semver"
+)
+
+func TestNext(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		level   semver.Bump
+		want    string
+	}{
+		{"patch increments patch", "1.2.3", semver.BumpPatch, "1.2.4"},
+		{"minor zeros patch", "1.2.3", semver.BumpMinor, "1.3.0"},
+		{"major zeros minor and patch", "1.2.3", semver.BumpMajor, "2.0.0"},
+		{"v-prefix preserved on patch", "v1.2.3", semver.BumpPatch, "v1.2.4"},
+		{"v-prefix preserved on major", "v1.2.3", semver.BumpMajor, "v2.0.0"},
+		{"prerelease dropped on patch", "1.2.3-rc.1", semver.BumpPatch, "1.2.3"},
+		{"prerelease dropped on minor", "1.2.3-rc.1", semver.BumpMinor, "1.3.0"},
+		{"build metadata dropped on patch", "1.2.3+build.42", semver.BumpPatch, "1.2.4"},
+		{"none returns input unchanged", "1.2.3", semver.BumpNone, "1.2.3"},
+		{"none preserves prerelease", "1.2.3-rc.1", semver.BumpNone, "1.2.3-rc.1"},
+		{"none preserves v prefix", "v1.2.3", semver.BumpNone, "v1.2.3"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := semver.Next(tc.version, tc.level)
+			if err != nil {
+				t.Fatalf("Next(%q, %s): unexpected error: %v", tc.version, tc.level, err)
+			}
+			if got != tc.want {
+				t.Errorf("Next(%q, %s) = %q, want %q", tc.version, tc.level, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNext_RejectsUnparseableVersion(t *testing.T) {
+	_, err := semver.Next("not-a-version", semver.BumpPatch)
+	if err == nil {
+		t.Fatal("Next(not-a-version, patch): want error, got nil")
+	}
+}

--- a/internal/versionfile/text/text.go
+++ b/internal/versionfile/text/text.go
@@ -1,0 +1,49 @@
+// Package text reads and writes whole-file plain-text version files.
+//
+// The version is the file body with surrounding whitespace stripped. Write
+// preserves the trailing-newline convention of the existing file: if the
+// previous content ended with a newline, the rewrite ends with one too.
+package text
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Read returns the version string at path. Surrounding whitespace
+// (including any trailing newline) is stripped.
+func Read(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	v := strings.TrimSpace(string(data))
+	if v == "" {
+		return "", fmt.Errorf("read %s: empty version file", path)
+	}
+	return v, nil
+}
+
+// Write replaces the contents of path with version, preserving whether the
+// original file ended with a newline.
+func Write(path, version string) error {
+	prev, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	body := version
+	if bytes.HasSuffix(prev, []byte("\n")) {
+		body += "\n"
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(body), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/versionfile/text/text_test.go
+++ b/internal/versionfile/text/text_test.go
@@ -1,0 +1,107 @@
+package text_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ThomasK33/vp/internal/versionfile/text"
+)
+
+func TestRead(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"trailing newline stripped", "1.2.3\n", "1.2.3"},
+		{"no trailing newline", "1.2.3", "1.2.3"},
+		{"surrounding whitespace stripped", "  1.2.3  \n", "1.2.3"},
+		{"prerelease preserved", "v1.2.3-rc.1\n", "v1.2.3-rc.1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "VERSION")
+			if err := os.WriteFile(path, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, err := text.Read(path)
+			if err != nil {
+				t.Fatalf("Read: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Read(%q) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRead_RejectsEmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "VERSION")
+	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := text.Read(path); err == nil {
+		t.Fatal("Read(empty): want error, got nil")
+	}
+}
+
+func TestRead_RejectsMissingFile(t *testing.T) {
+	if _, err := text.Read(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("Read(missing): want error, got nil")
+	}
+}
+
+func TestWrite_PreservesTrailingNewline(t *testing.T) {
+	cases := []struct {
+		name string
+		prev string
+		next string
+		want string
+	}{
+		{"with trailing newline", "1.2.3\n", "1.2.4", "1.2.4\n"},
+		{"without trailing newline", "1.2.3", "1.2.4", "1.2.4"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "VERSION")
+			if err := os.WriteFile(path, []byte(tc.prev), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := text.Write(path, tc.next); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("file after Write = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadWrite_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "VERSION")
+	if err := os.WriteFile(path, []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cur, err := text.Read(path)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if cur != "1.2.3" {
+		t.Fatalf("Read = %q, want %q", cur, "1.2.3")
+	}
+	if err := text.Write(path, "1.2.4"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "1.2.4\n" {
+		t.Errorf("round-trip body = %q, want %q", got, "1.2.4\n")
+	}
+}


### PR DESCRIPTION
Closes #6.

## Summary

- `internal/semver.Next` — bump arithmetic via Masterminds/semver/v3 with stable-promotion semantics (drops prerelease/build) per ADR-0003 and `v`-prefix preservation.
- `internal/versionfile/text` — whole-file version reader/writer that preserves the trailing-newline convention via `tmp + rename`.
- `vp apply` — two-phase atomic command. Phase 1 validates components, bumps, formats, and semver in read-only mode; Phase 2 writes version files first, then deletes plan files. `--dry-run` prints a planned-changes table without touching disk. All-none plans consume plans without writing version files. Archive consumption mode and non-text formats with a non-none bump are rejected (planned for later slices).
- `vp status` — upgraded to show `current -> next` for text-format components; non-text components keep the bare format.
- `cmd/resolve.go` — factored the shared plan-walk-and-collapse logic used by both `vp apply` and `vp status`.
- `runVP` test helper now resets pflag state between invocations so per-command flags don't leak across tests.

## Acceptance criteria (issue #6)

- [x] `internal/semver.Next` covers `1.2.3 patch/minor/major`, `v` preservation, prerelease/build drop, and `none` returning input unchanged.
- [x] `internal/versionfile/text` Read/Write preserve trailing-newline behavior.
- [x] `vp apply --dry-run` prints `component`, `current`, `next`, `bump`, `file`.
- [x] `vp apply` writes version files then deletes plan files; Phase 1 failures produce no side effects.
- [x] All-none plans consume plans without writing version files; output says "no version changes".
- [x] Missing version path or unparseable semver fails Phase 1 with file-path-bearing errors and no side effects.
- [x] `vp status` shows current/next for text-format components.
- [x] Exit codes: 0 / 2 (usage/config) / 3 (runtime).
- [x] Tests: table tests for `Next`, golden tests for `versionfile/text`, e2e tests for `vp apply` (happy path, dry-run, all-none, Phase 1 failure, missing path, archive rejection, non-text rejection).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run`
- [x] Manual e2e smoke: text component, `vp add cli minor`, `vp status` shows arrow, `vp apply --dry-run` table-only, `vp apply` writes file and consumes plan, all-none + archive-mode rejection paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)