### PR TITLE
Slice 6: vp check + git.ChangedFiles + config.Affected

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -2,18 +2,107 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/ThomasK33/vp/internal/config"
+	"github.com/ThomasK33/vp/internal/git"
+	"github.com/ThomasK33/vp/internal/plan"
 )
 
 var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Validate that every affected component is covered by a pending plan.",
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return errors.New("not yet implemented")
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		base, err := cmd.Flags().GetString("base")
+		if err != nil {
+			return err
+		}
+		head, err := cmd.Flags().GetString("head")
+		if err != nil {
+			return err
+		}
+		if base == "" || head == "" {
+			return usageError(errors.New("--base and --head are required"))
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		cfg, err := config.Load(cwd)
+		if err != nil {
+			if errors.Is(err, config.ErrNotFound) {
+				return usageError(err)
+			}
+			return err
+		}
+
+		changed, err := git.ChangedFiles(cfg.Dir, base, head)
+		if err != nil {
+			return err
+		}
+
+		affected, err := cfg.Affected(changed)
+		if err != nil {
+			return usageError(err)
+		}
+
+		pending, err := plan.LoadDir(cfg.Plans.Dir)
+		if err != nil {
+			return usageError(err)
+		}
+		planned := plannedComponents(pending)
+
+		var missing []string
+		for _, name := range affected {
+			if !planned[name] {
+				missing = append(missing, name)
+			}
+		}
+
+		out := cmd.OutOrStdout()
+		printCheckReport(out, affected, sortedKeys(planned), missing)
+		if len(missing) > 0 {
+			return checkError(fmt.Errorf("missing plan coverage for: %s", strings.Join(missing, ", ")))
+		}
+		return nil
 	},
 }
 
+func plannedComponents(pending []plan.Pending) map[string]bool {
+	m := make(map[string]bool, len(pending))
+	for _, p := range pending {
+		for name := range p.Plan.Releases {
+			m[name] = true
+		}
+	}
+	return m
+}
+
+func printCheckReport(out io.Writer, affected, planned, missing []string) {
+	_, _ = fmt.Fprintf(out, "Affected components: %s\n", joinOrNone(affected))
+	_, _ = fmt.Fprintf(out, "Planned components:  %s\n", joinOrNone(planned))
+	if len(missing) > 0 {
+		_, _ = fmt.Fprintf(out, "Missing coverage:    %s\n", strings.Join(missing, ", "))
+		return
+	}
+	_, _ = fmt.Fprintln(out, "All affected components are covered.")
+}
+
+func joinOrNone(s []string) string {
+	if len(s) == 0 {
+		return "(none)"
+	}
+	return strings.Join(s, ", ")
+}
+
 func init() {
+	checkCmd.Flags().String("base", "", "git ref to compare from (required)")
+	checkCmd.Flags().String("head", "", "git ref to compare to (required)")
 	rootCmd.AddCommand(checkCmd)
 }

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,0 +1,224 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const checkTestConfig = `
+plans:
+  dir: .version-plans
+  consumed: delete
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {file: VERSION, format: text}
+  agent:
+    paths: ["agent/**"]
+    version: {file: AGENT_VERSION, format: text}
+`
+
+// gitInRepo runs git args in dir, failing the test on non-zero exit.
+func gitInRepo(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// initCheckRepo creates a fresh git repo at dir with the canonical vp.yaml,
+// commits an initial state, then returns. Subsequent commits are the caller's
+// responsibility — that's what the diff under check will see.
+func initCheckRepo(t *testing.T, dir string) {
+	t.Helper()
+	gitInRepo(t, dir, "init", "-q", "-b", "main")
+	gitInRepo(t, dir, "config", "user.email", "vp-test@example.com")
+	gitInRepo(t, dir, "config", "user.name", "vp test")
+	gitInRepo(t, dir, "config", "commit.gpgsign", "false")
+
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(checkTestConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("0.1.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "AGENT_VERSION"), []byte("0.1.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cli", "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "agent", "agent.go"), []byte("package agent\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, dir, "add", ".")
+	gitInRepo(t, dir, "commit", "-q", "-m", "base")
+}
+
+func TestCheck_AllAffectedCovered(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	initCheckRepo(t, dir)
+
+	// Modify cli; add a plan covering cli; commit both.
+	if err := os.WriteFile(filepath.Join(dir, "cli", "main.go"), []byte("package main\n// changed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-cli.yaml", "releases:\n  cli: minor\n")
+	gitInRepo(t, dir, "add", ".")
+	gitInRepo(t, dir, "commit", "-q", "-m", "feat: cli change with plan")
+
+	stdout, _, err := runVP(t, "check", "--base", "HEAD~1", "--head", "HEAD")
+	if err != nil {
+		t.Fatalf("vp check: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "All affected components are covered.") {
+		t.Errorf("stdout missing success line:\n%s", got)
+	}
+	if !strings.Contains(got, "Affected components: cli") {
+		t.Errorf("stdout missing affected-cli line:\n%s", got)
+	}
+}
+
+func TestCheck_MissingCoverageExits1(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	initCheckRepo(t, dir)
+
+	// Modify agent without a covering plan.
+	if err := os.WriteFile(filepath.Join(dir, "agent", "agent.go"), []byte("package agent\n// new\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, dir, "add", ".")
+	gitInRepo(t, dir, "commit", "-q", "-m", "feat: agent change")
+
+	stdout, _, err := runVP(t, "check", "--base", "HEAD~1", "--head", "HEAD")
+	if err == nil {
+		t.Fatal("vp check: want error, got nil")
+	}
+	coded, ok := errors.AsType[*exitCodeError](err)
+	if !ok || coded.code != exitCheckError {
+		t.Fatalf("vp check error = %v (want code %d)", err, exitCheckError)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "Missing coverage:") || !strings.Contains(got, "agent") {
+		t.Errorf("stdout missing 'Missing coverage: ... agent':\n%s", got)
+	}
+}
+
+func TestCheck_PlansDirChurnIgnored(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	initCheckRepo(t, dir)
+
+	// Only change is a new plan file under .version-plans/.
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-noop.yaml", "releases:\n  cli: none\n")
+	gitInRepo(t, dir, "add", ".")
+	gitInRepo(t, dir, "commit", "-q", "-m", "chore: add plan")
+
+	stdout, _, err := runVP(t, "check", "--base", "HEAD~1", "--head", "HEAD")
+	if err != nil {
+		t.Fatalf("vp check: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "Affected components: (none)") {
+		t.Errorf("stdout should report no affected components when only plans churned:\n%s", got)
+	}
+}
+
+func TestCheck_VpYamlChangeIgnored(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	initCheckRepo(t, dir)
+
+	// Touch vp.yaml; nothing else.
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(checkTestConfig+"\n# touch\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, dir, "add", ".")
+	gitInRepo(t, dir, "commit", "-q", "-m", "chore: touch config")
+
+	stdout, _, err := runVP(t, "check", "--base", "HEAD~1", "--head", "HEAD")
+	if err != nil {
+		t.Fatalf("vp check: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Affected components: (none)") {
+		t.Errorf("vp.yaml change should yield no affected components:\n%s", stdout.String())
+	}
+}
+
+// Stack coverage (ADR-0001): a plan committed in an earlier diff still
+// satisfies the check for a later code-only diff.
+func TestCheck_StackCoveragePlanFromEarlierDiff(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	initCheckRepo(t, dir)
+
+	// Commit 1 (HEAD~1 from base view): add a plan covering cli.
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-02-early-cli.yaml", "releases:\n  cli: minor\n")
+	gitInRepo(t, dir, "add", ".")
+	gitInRepo(t, dir, "commit", "-q", "-m", "chore: pre-stage cli plan")
+
+	// Commit 2 (HEAD): code-only change to cli. The covering plan is NOT in this diff.
+	if err := os.WriteFile(filepath.Join(dir, "cli", "main.go"), []byte("package main\n// later\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, dir, "add", ".")
+	gitInRepo(t, dir, "commit", "-q", "-m", "feat: cli code change")
+
+	stdout, _, err := runVP(t, "check", "--base", "HEAD~1", "--head", "HEAD")
+	if err != nil {
+		t.Fatalf("vp check (stack-coverage): %v", err)
+	}
+	if !strings.Contains(stdout.String(), "All affected components are covered.") {
+		t.Errorf("stack-coverage diff should pass:\n%s", stdout.String())
+	}
+}
+
+func TestCheck_MissingFlagsIsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	initCheckRepo(t, dir)
+
+	_, _, err := runVP(t, "check")
+	assertUsageError(t, err)
+}
+
+func TestCheck_MissingConfigIsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	// no vp.yaml anywhere up the tree
+
+	_, _, err := runVP(t, "check", "--base", "HEAD~1", "--head", "HEAD")
+	assertUsageError(t, err)
+}
+
+func TestCheck_BogusRefIsRuntimeError(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	initCheckRepo(t, dir)
+
+	_, _, err := runVP(t, "check", "--base", "no-such-ref", "--head", "HEAD")
+	if err == nil {
+		t.Fatal("vp check: want error, got nil")
+	}
+	if _, ok := errors.AsType[*exitCodeError](err); ok {
+		t.Fatalf("vp check error wrapped as exit-coded; want bare runtime error: %v", err)
+	}
+}

--- a/cmd/exitcode.go
+++ b/cmd/exitcode.go
@@ -17,3 +17,8 @@ func (e *exitCodeError) Unwrap() error { return e.err }
 func usageError(err error) error {
 	return &exitCodeError{code: exitUsageError, err: err}
 }
+
+// checkError wraps err so Execute() exits with the vp-check failure code (1).
+func checkError(err error) error {
+	return &exitCodeError{code: exitCheckError, err: err}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ import (
 //	2 - usage / config error
 //	3 - runtime error
 const (
+	exitCheckError   = 1
 	exitUsageError   = 2
 	exitRuntimeError = 3
 )

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,10 @@ go 1.26.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	go.yaml.in/yaml/v3 v3.0.4
 )
 
-require (
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
-)
+require github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/internal/config/affected.go
+++ b/internal/config/affected.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// Affected returns the sorted set of component names whose path globs match at
+// least one entry in changedPaths. Paths under cfg.Plans.Dir and the vp.yaml
+// file itself are ignored — planning churn never triggers a coverage check.
+//
+// changedPaths must be relative to cfg.Dir (the directory containing vp.yaml).
+func (cfg *Config) Affected(changedPaths []string) ([]string, error) {
+	plansRel, err := filepath.Rel(cfg.Dir, cfg.Plans.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("plans.dir: %w", err)
+	}
+	plansRel = filepath.ToSlash(plansRel)
+
+	seen := make(map[string]bool)
+	for _, raw := range changedPaths {
+		p := filepath.ToSlash(filepath.Clean(raw))
+		if p == Filename {
+			continue
+		}
+		if isUnderDir(p, plansRel) {
+			continue
+		}
+		for name, comp := range cfg.Components {
+			if seen[name] {
+				continue
+			}
+			for _, glob := range comp.Paths {
+				ok, err := doublestar.Match(filepath.ToSlash(glob), p)
+				if err != nil {
+					return nil, fmt.Errorf("component %s: bad glob %q: %w", name, glob, err)
+				}
+				if ok {
+					seen[name] = true
+					break
+				}
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func isUnderDir(p, dir string) bool {
+	if dir == "" || dir == "." {
+		return false
+	}
+	return p == dir || strings.HasPrefix(p, dir+"/")
+}

--- a/internal/config/affected_test.go
+++ b/internal/config/affected_test.go
@@ -1,0 +1,163 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/ThomasK33/vp/internal/config"
+)
+
+// loadCfg writes body to <dir>/vp.yaml and loads it.
+func loadCfg(t *testing.T, body string) *config.Config {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	return cfg
+}
+
+const oneComponentYAML = `
+plans:
+  dir: .version-plans
+  consumed: delete
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {file: VERSION, format: text}
+`
+
+func TestAffected_SingleComponentSingleMatch(t *testing.T) {
+	cfg := loadCfg(t, oneComponentYAML)
+
+	got, err := cfg.Affected([]string{"cli/main.go"})
+	if err != nil {
+		t.Fatalf("Affected: %v", err)
+	}
+	want := []string{"cli"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Affected = %v, want %v", got, want)
+	}
+}
+
+const overlappingComponentsYAML = `
+plans:
+  dir: .version-plans
+  consumed: delete
+components:
+  cli:
+    paths: ["cli/**", "shared/**"]
+    version: {file: VERSION, format: text}
+  agent:
+    paths: ["agent/**", "shared/**"]
+    version: {file: AGENT_VERSION, format: text}
+`
+
+func TestAffected_OverlappingGlobsAffectMultipleComponents(t *testing.T) {
+	cfg := loadCfg(t, overlappingComponentsYAML)
+
+	got, err := cfg.Affected([]string{"shared/util.go"})
+	if err != nil {
+		t.Fatalf("Affected: %v", err)
+	}
+	want := []string{"agent", "cli"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Affected = %v, want %v", got, want)
+	}
+}
+
+// Catch-all globs would otherwise match plan files and vp.yaml; Affected
+// must filter those out so planning churn never triggers a coverage check.
+const catchAllYAML = `
+plans:
+  dir: .version-plans
+  consumed: delete
+components:
+  any:
+    paths: ["**"]
+    version: {file: VERSION, format: text}
+`
+
+func TestAffected_IgnoresPlanFiles(t *testing.T) {
+	cfg := loadCfg(t, catchAllYAML)
+
+	got, err := cfg.Affected([]string{".version-plans/2026-05-03-fix.yaml"})
+	if err != nil {
+		t.Fatalf("Affected: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("Affected = %v, want empty (plan files must be ignored)", got)
+	}
+}
+
+func TestAffected_IgnoresVpYaml(t *testing.T) {
+	cfg := loadCfg(t, catchAllYAML)
+
+	got, err := cfg.Affected([]string{"vp.yaml"})
+	if err != nil {
+		t.Fatalf("Affected: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("Affected = %v, want empty (vp.yaml must be ignored)", got)
+	}
+}
+
+// When the plans dir lives at a non-default nested path, Affected must still
+// strip changes under it. The doublestar `**` glob would otherwise match.
+const nestedPlansDirYAML = `
+plans:
+  dir: chart/.plans
+  consumed: delete
+components:
+  any:
+    paths: ["**"]
+    version: {file: VERSION, format: text}
+`
+
+func TestAffected_IgnoresNestedPlansDir(t *testing.T) {
+	cfg := loadCfg(t, nestedPlansDirYAML)
+
+	got, err := cfg.Affected([]string{"chart/.plans/2026-05-03-fix.yaml"})
+	if err != nil {
+		t.Fatalf("Affected: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("Affected = %v, want empty (nested plans dir must be ignored)", got)
+	}
+}
+
+func TestAffected_NoMatchReturnsEmpty(t *testing.T) {
+	cfg := loadCfg(t, oneComponentYAML)
+
+	got, err := cfg.Affected([]string{"docs/README.md"})
+	if err != nil {
+		t.Fatalf("Affected: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("Affected = %v, want empty", got)
+	}
+}
+
+func TestAffected_BadGlobReturnsError(t *testing.T) {
+	const badGlobYAML = `
+plans:
+  dir: .version-plans
+  consumed: delete
+components:
+  cli:
+    paths: ["[unclosed"]
+    version: {file: VERSION, format: text}
+`
+	cfg := loadCfg(t, badGlobYAML)
+
+	_, err := cfg.Affected([]string{"cli/main.go"})
+	if err == nil {
+		t.Fatal("Affected: want error for bad glob, got nil")
+	}
+}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -1,0 +1,33 @@
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ChangedFiles returns the file paths changed between base and head as
+// reported by `git diff --name-only --relative base...head` run from dir.
+// Paths returned are relative to dir. (nil, nil) means no files changed.
+func ChangedFiles(dir, base, head string) ([]string, error) {
+	cmd := exec.Command("git", "-C", dir, "diff", "--name-only", "--relative", base+"..."+head)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			return nil, fmt.Errorf("git diff %s...%s: %w", base, head, err)
+		}
+		return nil, fmt.Errorf("git diff %s...%s: %w: %s", base, head, err, msg)
+	}
+	var out []string
+	for line := range strings.SplitSeq(stdout.String(), "\n") {
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out, nil
+}

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,0 +1,88 @@
+package git_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/ThomasK33/vp/internal/git"
+)
+
+// initRepo runs the minimum git invocations needed to produce a working tree
+// with a configured identity at dir. Mise provides git on CI.
+func initRepo(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"config", "user.email", "vp-test@example.com"},
+		{"config", "user.name", "vp test"},
+		{"config", "commit.gpgsign", "false"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+func gitDo(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func writeFile(t *testing.T, dir, rel, body string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestChangedFiles_TwoCommits(t *testing.T) {
+	dir := t.TempDir()
+	initRepo(t, dir)
+
+	writeFile(t, dir, "cli/main.go", "package main\n")
+	writeFile(t, dir, "README.md", "old\n")
+	gitDo(t, dir, "add", ".")
+	gitDo(t, dir, "commit", "-q", "-m", "base")
+
+	writeFile(t, dir, "cli/main.go", "package main\n// changed\n")
+	writeFile(t, dir, "agent/agent.go", "package agent\n")
+	gitDo(t, dir, "add", ".")
+	gitDo(t, dir, "commit", "-q", "-m", "head")
+
+	got, err := git.ChangedFiles(dir, "HEAD~1", "HEAD")
+	if err != nil {
+		t.Fatalf("ChangedFiles: %v", err)
+	}
+	sort.Strings(got)
+	want := []string{"agent/agent.go", "cli/main.go"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ChangedFiles = %v, want %v", got, want)
+	}
+}
+
+func TestChangedFiles_BogusRefReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	initRepo(t, dir)
+	writeFile(t, dir, "a.txt", "1\n")
+	gitDo(t, dir, "add", ".")
+	gitDo(t, dir, "commit", "-q", "-m", "init")
+
+	_, err := git.ChangedFiles(dir, "no-such-ref", "HEAD")
+	if err == nil {
+		t.Fatal("ChangedFiles: want error for bogus ref, got nil")
+	}
+}


### PR DESCRIPTION
Closes #7.

## Summary

- `internal/git.ChangedFiles(dir, base, head)` — shells `git diff --name-only --relative <base>...<head>` from `dir` (callers pass `cfg.Dir`) so returned paths align with component path globs in the config.
- `(*Config).Affected(changedPaths)` — glob-matches changed paths against component path globs via `bmatcuk/doublestar/v4`. Files under `cfg.Plans.Dir` and the `vp.yaml` file itself are excluded so planning churn never triggers a coverage check. Overlapping globs are accepted (a single file may make multiple components affected).
- `vp check --base <ref> --head <ref>` — implements stack-coverage validation per ADR-0001: a pending plan authored in an earlier diff still satisfies the check, even when it is not part of `<base>...<head>`. Prints a three-line report (Affected / Planned / Missing or success) and returns the appropriate exit code.
- New exit code constant `exitCheckError = 1` and `checkError(err)` helper in `cmd/exitcode.go`.

## Acceptance criteria (issue #7)

- [x] `internal/git.ChangedFiles` returns the list of changed file paths between two refs via `git diff --name-only`.
- [x] `internal/config.Affected` returns the set of components whose path globs match any changed file. Files under `plans.dir` and `vp.yaml` itself are excluded.
- [x] `vp check --base <ref> --head <ref>` prints affected / planned / missing components; exits 0 if all affected components are covered.
- [x] `vp check` exits 1 if any affected component is not mentioned by any pending plan.
- [x] `vp check` exits 2 on usage/config errors and 3 on git or filesystem errors.
- [x] Stack-coverage semantics confirmed (`TestCheck_StackCoveragePlanFromEarlierDiff`): a plan authored in an earlier diff covers the current check.
- [x] Overlapping component path globs accepted (`TestAffected_OverlappingGlobsAffectMultipleComponents`).
- [x] Tests: `Affected` table tests with overlapping/ignore cases; `git.ChangedFiles` integration test using `git init` in `t.TempDir()`; e2e `vp check` covering pass/fail and the stack-coverage invariant.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run`
- [x] Manual smoke: `vp check` (no flags) -> exit 2; `vp check --base ... --head ...` against an unconfigured repo -> exit 2 with `vp.yaml not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)