### PR TITLE
Slice 9: versionfile/toml with surgical edits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 	go.yaml.in/yaml/v3 v3.0.4

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fT
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
+github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=

--- a/internal/versionfile/toml/testdata/cargo/after.toml
+++ b/internal/versionfile/toml/testdata/cargo/after.toml
@@ -1,0 +1,8 @@
+[package]
+name = "demo"
+version = "1.2.4"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.35", features = ["full"] }

--- a/internal/versionfile/toml/testdata/cargo/before.toml
+++ b/internal/versionfile/toml/testdata/cargo/before.toml
@@ -1,0 +1,8 @@
+[package]
+name = "demo"
+version = "1.2.3"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.35", features = ["full"] }

--- a/internal/versionfile/toml/testdata/comments/after.toml
+++ b/internal/versionfile/toml/testdata/comments/after.toml
@@ -1,0 +1,8 @@
+# Project metadata.
+# Maintained by the platform team.
+
+[package]
+name = "demo"
+# Bumped on each release.
+version = "1.2.4" # pinned by release pipeline
+edition = "2021"

--- a/internal/versionfile/toml/testdata/comments/before.toml
+++ b/internal/versionfile/toml/testdata/comments/before.toml
@@ -1,0 +1,8 @@
+# Project metadata.
+# Maintained by the platform team.
+
+[package]
+name = "demo"
+# Bumped on each release.
+version = "1.2.3" # pinned by release pipeline
+edition = "2021"

--- a/internal/versionfile/toml/testdata/dotted-key/after.toml
+++ b/internal/versionfile/toml/testdata/dotted-key/after.toml
@@ -1,0 +1,3 @@
+name = "demo"
+package.version = "0.2.0"
+package.edition = "2021"

--- a/internal/versionfile/toml/testdata/dotted-key/before.toml
+++ b/internal/versionfile/toml/testdata/dotted-key/before.toml
@@ -1,0 +1,3 @@
+name = "demo"
+package.version = "0.1.0"
+package.edition = "2021"

--- a/internal/versionfile/toml/testdata/multi-table/after.toml
+++ b/internal/versionfile/toml/testdata/multi-table/after.toml
@@ -1,0 +1,12 @@
+version = "1.2.4"
+
+[server]
+host = "localhost"
+port = 8080
+
+[database]
+url = "postgres://localhost/demo"
+pool_size = 10
+
+[logging]
+level = "info"

--- a/internal/versionfile/toml/testdata/multi-table/before.toml
+++ b/internal/versionfile/toml/testdata/multi-table/before.toml
@@ -1,0 +1,12 @@
+version = "1.2.3"
+
+[server]
+host = "localhost"
+port = 8080
+
+[database]
+url = "postgres://localhost/demo"
+pool_size = 10
+
+[logging]
+level = "info"

--- a/internal/versionfile/toml/testdata/pyproject/after.toml
+++ b/internal/versionfile/toml/testdata/pyproject/after.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "demo"
+version = "1.2.4"
+description = "demo package"
+requires-python = ">=3.10"
+
+[tool.ruff]
+line-length = 100

--- a/internal/versionfile/toml/testdata/pyproject/before.toml
+++ b/internal/versionfile/toml/testdata/pyproject/before.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "demo"
+version = "1.2.3"
+description = "demo package"
+requires-python = ">=3.10"
+
+[tool.ruff]
+line-length = 100

--- a/internal/versionfile/toml/testdata/toplevel/after.toml
+++ b/internal/versionfile/toml/testdata/toplevel/after.toml
@@ -1,0 +1,2 @@
+version = "1.2.4"
+name = "demo"

--- a/internal/versionfile/toml/testdata/toplevel/before.toml
+++ b/internal/versionfile/toml/testdata/toplevel/before.toml
@@ -1,0 +1,2 @@
+version = "1.2.3"
+name = "demo"

--- a/internal/versionfile/toml/toml.go
+++ b/internal/versionfile/toml/toml.go
@@ -1,0 +1,128 @@
+// Package toml reads and surgically writes TOML version files using the
+// validate-then-splice approach from ADR-0002: parse with the
+// pelletier/go-toml/v2/unstable position-aware parser, walk top-level
+// expressions to the target dotted key path, and splice only the leaf
+// string's inner byte span — never round-tripping the document. The rest
+// of the file is preserved byte-for-byte: comments, key order, table
+// headers, and surrounding whitespace.
+package toml
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+// Read returns the version string at tomlPath (a dotted path like
+// "version" or "package.version"). Errors if the path is missing or
+// resolves to a non-string value.
+func Read(file, tomlPath string) (string, error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", file, err)
+	}
+	_, _, value, err := locate(data, tomlPath)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", file, err)
+	}
+	return value, nil
+}
+
+// Write replaces the string value at tomlPath with version. Only the
+// inner value bytes are rewritten; surrounding quotes are kept and the
+// rest of the file is preserved byte-for-byte. Errors before writing if
+// the path is missing or resolves to anything other than a basic or
+// literal single-line string.
+func Write(file, tomlPath, version string) error {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("write %s: %w", file, err)
+	}
+	start, end, _, err := locate(data, tomlPath)
+	if err != nil {
+		return fmt.Errorf("write %s: %w", file, err)
+	}
+	out := make([]byte, 0, len(data)-(end-start)+len(version))
+	out = append(out, data[:start]...)
+	out = append(out, version...)
+	out = append(out, data[end:]...)
+	tmp := file + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", file, err)
+	}
+	if err := os.Rename(tmp, file); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("write %s: %w", file, err)
+	}
+	return nil
+}
+
+func locate(data []byte, tomlPath string) (start, end int, value string, err error) {
+	if tomlPath == "" {
+		return 0, 0, "", fmt.Errorf("empty path")
+	}
+	targets := strings.Split(tomlPath, ".")
+	if slices.Contains(targets, "") {
+		return 0, 0, "", fmt.Errorf("path %q: empty segment", tomlPath)
+	}
+	var p unstable.Parser
+	p.Reset(data)
+	var currentTable []string
+	inArrayTable := false
+	for p.NextExpression() {
+		e := p.Expression()
+		switch e.Kind {
+		case unstable.Table:
+			currentTable = keySegments(e)
+			inArrayTable = false
+			continue
+		case unstable.ArrayTable:
+			inArrayTable = true
+			continue
+		case unstable.KeyValue:
+			if inArrayTable {
+				continue
+			}
+		default:
+			continue
+		}
+		segs := append(append([]string{}, currentTable...), keySegments(e)...)
+		if !slices.Equal(segs, targets) {
+			if isPrefix(segs, targets) {
+				return 0, 0, "", fmt.Errorf("path %q: expected table at segment %q", tomlPath, targets[len(segs)])
+			}
+			continue
+		}
+		v := e.Value()
+		if v.Kind != unstable.String {
+			return 0, 0, "", fmt.Errorf("path %q: value is not a string (got %s)", tomlPath, v.Kind)
+		}
+		tokenStart := int(v.Raw.Offset)
+		tokenEnd := tokenStart + int(v.Raw.Length)
+		token := data[tokenStart:tokenEnd]
+		if len(token) >= 6 && token[0] == token[1] && token[1] == token[2] {
+			return 0, 0, "", fmt.Errorf("path %q: value must be a basic or literal string", tomlPath)
+		}
+		return tokenStart + 1, tokenEnd - 1, string(token[1 : len(token)-1]), nil
+	}
+	if perr := p.Error(); perr != nil {
+		return 0, 0, "", fmt.Errorf("path %q: parse: %w", tomlPath, perr)
+	}
+	return 0, 0, "", fmt.Errorf("path %q: not found", tomlPath)
+}
+
+func isPrefix(prefix, full []string) bool {
+	return len(prefix) < len(full) && slices.Equal(prefix, full[:len(prefix)])
+}
+
+func keySegments(n *unstable.Node) []string {
+	var segs []string
+	it := n.Key()
+	for it.Next() {
+		segs = append(segs, string(it.Node().Data))
+	}
+	return segs
+}

--- a/internal/versionfile/toml/toml_test.go
+++ b/internal/versionfile/toml/toml_test.go
@@ -1,0 +1,244 @@
+package toml_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ThomasK33/vp/internal/versionfile/toml"
+)
+
+func TestRead_Paths(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		path string
+		want string
+	}{
+		{"top-level", "version = \"1.2.3\"\n", "version", "1.2.3"},
+		{"cargo-style", "[package]\nname = \"x\"\nversion = \"1.2.3\"\n", "package.version", "1.2.3"},
+		{"pyproject-style", "[project]\nname = \"x\"\nversion = \"1.2.3\"\n", "project.version", "1.2.3"},
+		{"dotted-key", "package.version = \"1.2.3\"\n", "package.version", "1.2.3"},
+		{"three-level header", "[workspace.package]\nversion = \"0.1.0\"\n", "workspace.package.version", "0.1.0"},
+		{"three-level dotted", "workspace.package.version = \"0.1.0\"\n", "workspace.package.version", "0.1.0"},
+		{"skips non-matching keys", "name = \"foo\"\nversion = \"1.2.3\"\ndescription = \"bar\"\n", "version", "1.2.3"},
+		{"literal string", "version = '1.2.3'\n", "version", "1.2.3"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "f.toml")
+			if err := os.WriteFile(path, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, err := toml.Read(path, tc.path)
+			if err != nil {
+				t.Fatalf("Read: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Read = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWrite_StylePreservation(t *testing.T) {
+	cases := []struct {
+		name   string
+		before string
+		path   string
+		old    string
+		new    string
+		after  string
+	}{
+		{"basic-string", "version = \"1.2.3\"\n", "version", "1.2.3", "1.2.4", "version = \"1.2.4\"\n"},
+		{"literal-string", "version = '1.2.3'\n", "version", "1.2.3", "1.2.4", "version = '1.2.4'\n"},
+		{"inline comment", "version = \"1.2.3\" # pinned\n", "version", "1.2.3", "1.2.4", "version = \"1.2.4\" # pinned\n"},
+		{"trailing whitespace on line", "version = \"1.2.3\"   \n", "version", "1.2.3", "1.2.4", "version = \"1.2.4\"   \n"},
+		{"cargo-style nested", "[package]\nname = \"x\"\nversion = \"1.2.3\"\n", "package.version", "1.2.3", "1.2.4", "[package]\nname = \"x\"\nversion = \"1.2.4\"\n"},
+		{"dotted-key", "package.version = \"1.2.3\"\n", "package.version", "1.2.3", "1.2.4", "package.version = \"1.2.4\"\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "f.toml")
+			if err := os.WriteFile(path, []byte(tc.before), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, err := toml.Read(path, tc.path)
+			if err != nil {
+				t.Fatalf("Read: %v", err)
+			}
+			if got != tc.old {
+				t.Fatalf("Read = %q, want %q", got, tc.old)
+			}
+			if err := toml.Write(path, tc.path, tc.new); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			gotAfter, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(gotAfter, []byte(tc.after)) {
+				t.Errorf("after Write:\n got = %q\nwant = %q", gotAfter, tc.after)
+			}
+		})
+	}
+}
+
+func TestWrite_Golden(t *testing.T) {
+	cases := []struct {
+		name    string
+		fixture string
+		path    string
+		oldVer  string
+		newVer  string
+	}{
+		{"toplevel", "toplevel", "version", "1.2.3", "1.2.4"},
+		{"cargo", "cargo", "package.version", "1.2.3", "1.2.4"},
+		{"pyproject", "pyproject", "project.version", "1.2.3", "1.2.4"},
+		{"comments", "comments", "package.version", "1.2.3", "1.2.4"},
+		{"multi-table", "multi-table", "version", "1.2.3", "1.2.4"},
+		{"dotted-key", "dotted-key", "package.version", "0.1.0", "0.2.0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before, err := os.ReadFile(filepath.Join("testdata", tc.fixture, "before.toml"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantAfter, err := os.ReadFile(filepath.Join("testdata", tc.fixture, "after.toml"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(t.TempDir(), "f.toml")
+			if err := os.WriteFile(path, before, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, err := toml.Read(path, tc.path)
+			if err != nil {
+				t.Fatalf("Read: %v", err)
+			}
+			if got != tc.oldVer {
+				t.Fatalf("Read = %q, want %q", got, tc.oldVer)
+			}
+			if err := toml.Write(path, tc.path, tc.newVer); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			gotAfter, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(gotAfter, wantAfter) {
+				t.Errorf("after Write:\n--- got  ---\n%s\n--- want ---\n%s", gotAfter, wantAfter)
+			}
+		})
+	}
+}
+
+func TestReadWrite_RoundTripIdempotent(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"basic", "name = \"x\"\nversion = \"1.2.3\"\nextra = \"y\"\n"},
+		{"literal", "name = 'x'\nversion = '1.2.3'\nextra = 'y'\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "f.toml")
+			if err := os.WriteFile(path, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cur, err := toml.Read(path, "version")
+			if err != nil {
+				t.Fatalf("Read: %v", err)
+			}
+			if err := toml.Write(path, "version", cur); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tc.body {
+				t.Errorf("round-trip body = %q, want %q", got, tc.body)
+			}
+		})
+	}
+}
+
+func TestWrite_ErrorsLeaveFileUnchanged(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		path string
+	}{
+		{"missing key", "name = \"x\"\n", "version"},
+		{"non-string leaf", "version = 123\n", "version"},
+		{"non-table midway", "version = \"1.0.0\"\n", "version.sub"},
+		{"multi-line basic string", "version = \"\"\"1.2.3\"\"\"\n", "version"},
+		{"malformed toml", "version = =\n", "version"},
+		{"empty path", "version = \"1.0.0\"\n", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "f.toml")
+			if err := os.WriteFile(path, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			err := toml.Write(path, tc.path, "9.9.9")
+			if err == nil {
+				t.Fatalf("Write: want error, got nil")
+			}
+			got, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if string(got) != tc.body {
+				t.Errorf("file changed after failed Write:\n got = %q\nwant = %q", got, tc.body)
+			}
+			if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+				t.Errorf("leftover %s.tmp", path)
+			}
+		})
+	}
+}
+
+func TestRead_Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		path    string
+		wantSub string
+	}{
+		{"missing key", "name = \"x\"\n", "version", "not found"},
+		{"non-string int leaf", "version = 123\n", "version", "is not a string"},
+		{"non-string float leaf", "version = 1.0\n", "version", "is not a string"},
+		{"non-string bool leaf", "version = true\n", "version", "is not a string"},
+		{"non-string array leaf", "version = [\"1.0.0\"]\n", "version", "is not a string"},
+		{"non-table midway", "version = \"1.0.0\"\n", "version.sub", "expected table"},
+		{"multi-line basic string", "version = \"\"\"1.2.3\"\"\"\n", "version", "basic or literal string"},
+		{"multi-line literal string", "version = '''1.2.3'''\n", "version", "basic or literal string"},
+		{"array table member ignored", "[[bin]]\nversion = \"1.0.0\"\n", "bin.version", "not found"},
+		{"inline table value", "package = { version = \"1.0.0\" }\n", "package.version", "expected table"},
+		{"malformed toml", "version = =\n", "version", "parse"},
+		{"empty path", "version = \"1.0.0\"\n", "", "empty path"},
+		{"empty segment", "version = \"1.0.0\"\n", "a..b", "empty segment"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "f.toml")
+			if err := os.WriteFile(path, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := toml.Read(path, tc.path)
+			if err == nil {
+				t.Fatalf("Read(%q, %q): want error, got nil", tc.body, tc.path)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("Read error = %v, want substring %q", err, tc.wantSub)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/versionfile/toml`: surgical Read/Write for TOML version files via `pelletier/go-toml/v2/unstable`. Per ADR-0002, the leaf string's inner byte span is spliced — comments, key order, table headers, and surrounding whitespace are preserved byte-for-byte. Multi-line strings, inline tables, and array-table members at the target path are rejected before any write.
- Resolves `package.version` against either the `[package]`-header form *or* the dotted-key form (`package.version = "..."`).
- Golden fixtures cover top-level, Cargo-style `[package]`, pyproject `[project]`, comments + inline comments, multi-table layouts, and dotted-key form.

Closes #10.

## Test plan
- [x] `go test ./internal/versionfile/toml/...` (Read paths, Write style preservation, Write goldens, idempotent round-trip, Read errors, Write-errors-leave-file-unchanged)
- [x] `go test ./...` (no regressions in json/yaml/text or cmd)
- [x] `go vet ./...`, `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)