### PR TITLE
Slice 11: --json output mode for status / apply / check

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,79 @@ does *not* generate changelogs or release notes.
 See [`CONTEXT.md`](./CONTEXT.md) for the domain glossary and
 [`docs/adr/`](./docs/adr/) for architectural decisions.
 
+## Output formats
+
+`vp status`, `vp apply` (incl. `--dry-run`), and `vp check` accept `--json`
+to emit a stable machine-readable payload on stdout. Plain text remains the
+default. The `--json` flag only affects stdout — error messages always go to
+stderr unchanged. The shape of every payload is pinned by golden files in
+`cmd/testdata/output/json/`; breaking changes will require a major-version
+bump once vp reaches `v1`.
+
+### `vp status --json`
+
+```json
+{
+  "pending": [
+    {
+      "file": "2026-05-03-fix.yaml",
+      "releases": { "cli": "minor" },
+      "message": "fix the thing"
+    }
+  ],
+  "resolved": [
+    { "component": "cli", "bump": "minor", "current": "1.2.3", "next": "1.3.0" }
+  ]
+}
+```
+
+`pending` is sorted by filename. `releases` is the raw map from the plan
+file. `message` is omitted when empty. `resolved` is sorted by component
+name; with `--all`, every configured component appears, including those
+with no pending bump (`bump: "none"`). `current` and `next` are populated
+when the component's version file is readable in any supported format
+(text/json/yaml/toml); they are omitted on read failure. `next` is also
+omitted when the resolved bump is `none`.
+
+### `vp apply --json` and `vp apply --dry-run --json`
+
+```json
+{
+  "changes": [
+    {
+      "component": "cli",
+      "current": "1.2.3",
+      "next": "1.3.0",
+      "bump": "minor",
+      "file": "VERSION",
+      "tag": "cli-v1.3.0"
+    }
+  ],
+  "consumed": ["2026-05-03-bump.yaml"]
+}
+```
+
+Both modes share one shape. `changes` is sorted by component name. `file`
+is repo-relative. `tag` is omitted when no template is configured for the
+component. `consumed` lists basenames of plans that were removed (in
+`delete` mode) or moved to the archive directory (in `archive` mode);
+it is always present as an empty array under `--dry-run`.
+
+### `vp check --json`
+
+```json
+{
+  "affected": ["cli"],
+  "planned": ["cli"],
+  "missing": []
+}
+```
+
+All three arrays are always present (never `null`) and sorted alphabetically.
+Exit code `1` is still returned when `missing` is non-empty; the JSON
+payload is emitted on stdout regardless, and the error message goes to
+stderr.
+
 ## License
 
 MIT — see [`LICENSE`](./LICENSE).

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ThomasK33/vp/internal/config"
+	"github.com/ThomasK33/vp/internal/output"
 	"github.com/ThomasK33/vp/internal/plan"
 	"github.com/ThomasK33/vp/internal/semver"
 	"github.com/ThomasK33/vp/internal/versionfile/text"
@@ -57,17 +58,26 @@ var applyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		jsonOut, err := cmd.Flags().GetBool("json")
+		if err != nil {
+			return err
+		}
 
 		out := cmd.OutOrStdout()
 		if dryRun {
+			if jsonOut {
+				return output.WriteApply(out, applyReport(cfg, changes, nil))
+			}
 			renderDryRun(out, cfg, changes)
 			return nil
 		}
 
-		if len(changes) == 0 {
-			_, _ = fmt.Fprintln(out, "no version changes")
-		} else {
-			renderApplied(out, cfg, changes)
+		if !jsonOut {
+			if len(changes) == 0 {
+				_, _ = fmt.Fprintln(out, "no version changes")
+			} else {
+				renderApplied(out, cfg, changes)
+			}
 		}
 
 		for _, ch := range changes {
@@ -79,9 +89,35 @@ var applyCmd = &cobra.Command{
 			return err
 		}
 
+		if jsonOut {
+			return output.WriteApply(out, applyReport(cfg, changes, pending))
+		}
 		_, _ = fmt.Fprintf(out, "Wrote %d file(s); consumed %d plan(s).\n", len(changes), len(pending))
 		return nil
 	},
+}
+
+// applyReport builds the JSON payload for both dry-run and live apply.
+// Pass consumed=nil for dry-run; the result's Consumed array is then empty.
+func applyReport(cfg *config.Config, changes []plannedChange, consumed []plan.Pending) *output.ApplyReport {
+	r := &output.ApplyReport{
+		Changes:  make([]output.Change, 0, len(changes)),
+		Consumed: []string{},
+	}
+	for _, ch := range changes {
+		r.Changes = append(r.Changes, output.Change{
+			Component: ch.name,
+			Current:   ch.current,
+			Next:      ch.next,
+			Bump:      string(ch.bump),
+			File:      relPath(cfg.Dir, ch.file),
+			Tag:       ch.tag,
+		})
+	}
+	for _, p := range consumed {
+		r.Consumed = append(r.Consumed, filepath.Base(p.Path))
+	}
+	return r
 }
 
 // planChanges turns collapsed bumps into plannedChange entries, validating
@@ -201,5 +237,6 @@ func relPath(base, p string) string {
 
 func init() {
 	applyCmd.Flags().Bool("dry-run", false, "show planned changes without writing files or consuming plans")
+	applyCmd.Flags().Bool("json", false, "emit machine-readable JSON to stdout")
 	rootCmd.AddCommand(applyCmd)
 }

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1,12 +1,28 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
+
+type applyJSON struct {
+	Changes  []applyChangeJSON `json:"changes"`
+	Consumed []string          `json:"consumed"`
+}
+
+type applyChangeJSON struct {
+	Component string `json:"component"`
+	Current   string `json:"current"`
+	Next      string `json:"next"`
+	Bump      string `json:"bump"`
+	File      string `json:"file"`
+	Tag       string `json:"tag,omitempty"`
+}
 
 const applyTestConfigText = `
 plans:
@@ -187,6 +203,182 @@ func TestApply_TagTemplateRenderedInOutput(t *testing.T) {
 	}
 	if !strings.Contains(applyStdout.String(), "cli-v1.3.0") {
 		t.Errorf("apply output missing rendered tag cli-v1.3.0:\n%s", applyStdout.String())
+	}
+}
+
+func TestApply_DryRunJSONEmitsObjectWithEmptyConsumed(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeApplyTextConfig(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	planPath := filepath.Join(plansDir, "2026-05-03-bump.yaml")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "apply", "--dry-run", "--json")
+	if err != nil {
+		t.Fatalf("vp apply --dry-run --json: %v", err)
+	}
+
+	// Dry run must not write or consume.
+	got, _ := os.ReadFile(filepath.Join(dir, "VERSION"))
+	if string(got) != "1.2.3\n" {
+		t.Errorf("VERSION changed during dry-run: %q", got)
+	}
+	if _, err := os.Stat(planPath); err != nil {
+		t.Errorf("plan file consumed during dry-run: %v", err)
+	}
+
+	var report applyJSON
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse json: %v\nstdout: %s", err, stdout.String())
+	}
+	if len(report.Changes) != 1 {
+		t.Fatalf("changes len = %d, want 1", len(report.Changes))
+	}
+	c := report.Changes[0]
+	if c.Component != "cli" || c.Current != "1.2.3" || c.Next != "1.3.0" || c.Bump != "minor" || c.File != "VERSION" {
+		t.Errorf("change = %+v", c)
+	}
+	if c.Tag != "" {
+		t.Errorf("tag should be empty when no template configured, got %q", c.Tag)
+	}
+	if report.Consumed == nil || len(report.Consumed) != 0 {
+		t.Errorf("consumed = %v, want empty non-nil array", report.Consumed)
+	}
+	if !strings.Contains(stdout.String(), `"consumed": []`) {
+		t.Errorf("expected empty consumed array in raw JSON, got:\n%s", stdout.String())
+	}
+}
+
+func TestApply_LiveJSONListsConsumedAndSuppressesTrailer(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeApplyTextConfig(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "apply", "--json")
+	if err != nil {
+		t.Fatalf("vp apply --json: %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(dir, "VERSION"))
+	if string(got) != "1.3.0\n" {
+		t.Errorf("VERSION after apply = %q, want 1.3.0\\n", got)
+	}
+
+	var report applyJSON
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse json: %v\nstdout: %s", err, stdout.String())
+	}
+	if !slices.Equal(report.Consumed, []string{"2026-05-03-bump.yaml"}) {
+		t.Errorf("consumed = %v, want [2026-05-03-bump.yaml]", report.Consumed)
+	}
+	if len(report.Changes) != 1 || report.Changes[0].Component != "cli" {
+		t.Errorf("changes = %+v", report.Changes)
+	}
+
+	// The text trailer "Wrote N file(s); consumed M plan(s)." must not leak into JSON stdout.
+	if strings.Contains(stdout.String(), "Wrote ") {
+		t.Errorf("stdout contains text trailer alongside JSON:\n%s", stdout.String())
+	}
+}
+
+func TestApply_JSONEmptyChangesAndConsumedWhenNothingPending(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeApplyTextConfig(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := runVP(t, "apply", "--json")
+	if err != nil {
+		t.Fatalf("vp apply --json: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"changes": []`) {
+		t.Errorf("expected empty changes array:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `"consumed": []`) {
+		t.Errorf("expected empty consumed array:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "no version changes") {
+		t.Errorf("text-mode message leaked into JSON:\n%s", stdout.String())
+	}
+}
+
+func TestApply_LiveJSONIncludesTagWhenConfigured(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	cfg := applyTestConfigText + "    tag: \"cli-v{version}\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "apply", "--dry-run", "--json")
+	if err != nil {
+		t.Fatalf("vp apply --dry-run --json: %v", err)
+	}
+	var report applyJSON
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	if report.Changes[0].Tag != "cli-v1.3.0" {
+		t.Errorf("tag = %q, want cli-v1.3.0", report.Changes[0].Tag)
+	}
+}
+
+func TestApply_ArchiveModeJSONStillReportsConsumed(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	cfg := strings.Replace(applyTestConfigText, "consumed: delete", "consumed: archive\n  archive_dir: .version-plans/archive", 1)
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "apply", "--json")
+	if err != nil {
+		t.Fatalf("vp apply --json: %v", err)
+	}
+	var report applyJSON
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	if !slices.Equal(report.Consumed, []string{"2026-05-03-bump.yaml"}) {
+		t.Errorf("consumed = %v, want [2026-05-03-bump.yaml] (basename, not archive path)", report.Consumed)
+	}
+}
+
+func TestApply_JSONUnknownComponentLeavesStdoutEmpty(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeApplyTextConfig(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-typo.yaml", "releases:\n  nope: minor\n")
+
+	stdout, _, err := runVP(t, "apply", "--json")
+	assertUsageError(t, err)
+	if stdout.Len() != 0 {
+		t.Errorf("stdout should be empty when apply errors before printing JSON, got:\n%s", stdout.String())
 	}
 }
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ThomasK33/vp/internal/config"
 	"github.com/ThomasK33/vp/internal/git"
+	"github.com/ThomasK33/vp/internal/output"
 	"github.com/ThomasK33/vp/internal/plan"
 )
 
@@ -65,8 +66,24 @@ var checkCmd = &cobra.Command{
 			}
 		}
 
+		jsonOut, err := cmd.Flags().GetBool("json")
+		if err != nil {
+			return err
+		}
+
 		out := cmd.OutOrStdout()
-		printCheckReport(out, affected, sortedKeys(planned), missing)
+		plannedNames := sortedKeys(planned)
+		if jsonOut {
+			if err := output.WriteCheck(out, &output.CheckReport{
+				Affected: affected,
+				Planned:  plannedNames,
+				Missing:  missing,
+			}); err != nil {
+				return err
+			}
+		} else {
+			printCheckReport(out, affected, plannedNames, missing)
+		}
 		if len(missing) > 0 {
 			return checkError(fmt.Errorf("missing plan coverage for: %s", strings.Join(missing, ", ")))
 		}
@@ -104,5 +121,6 @@ func joinOrNone(s []string) string {
 func init() {
 	checkCmd.Flags().String("base", "", "git ref to compare from (required)")
 	checkCmd.Flags().String("head", "", "git ref to compare to (required)")
+	checkCmd.Flags().Bool("json", false, "emit machine-readable JSON to stdout")
 	rootCmd.AddCommand(checkCmd)
 }

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -21,6 +23,12 @@ components:
     paths: ["agent/**"]
     version: {file: AGENT_VERSION, format: text}
 `
+
+type checkJSON struct {
+	Affected []string `json:"affected"`
+	Planned  []string `json:"planned"`
+	Missing  []string `json:"missing"`
+}
 
 // gitInRepo runs git args in dir, failing the test on non-zero exit.
 func gitInRepo(t *testing.T, dir string, args ...string) {
@@ -207,6 +215,108 @@ func TestCheck_MissingConfigIsUsageError(t *testing.T) {
 
 	_, _, err := runVP(t, "check", "--base", "HEAD~1", "--head", "HEAD")
 	assertUsageError(t, err)
+}
+
+func TestCheck_JSONCoveredEmitsArrays(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	initCheckRepo(t, dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "cli", "main.go"), []byte("package main\n// changed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-cli.yaml", "releases:\n  cli: minor\n")
+	gitInRepo(t, dir, "add", ".")
+	gitInRepo(t, dir, "commit", "-q", "-m", "feat: cli with plan")
+
+	stdout, _, err := runVP(t, "check", "--base", "HEAD~1", "--head", "HEAD", "--json")
+	if err != nil {
+		t.Fatalf("vp check --json: %v", err)
+	}
+
+	var got checkJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("parse json: %v\nstdout: %s", err, stdout.String())
+	}
+	if !slices.Equal(got.Affected, []string{"cli"}) {
+		t.Errorf("affected = %v, want [cli]", got.Affected)
+	}
+	if !slices.Equal(got.Planned, []string{"cli"}) {
+		t.Errorf("planned = %v, want [cli]", got.Planned)
+	}
+	if got.Missing == nil || len(got.Missing) != 0 {
+		t.Errorf("missing = %v, want empty non-nil array", got.Missing)
+	}
+	if !strings.Contains(stdout.String(), `"missing": []`) {
+		t.Errorf("expected empty missing to render as `[]` (not null), got:\n%s", stdout.String())
+	}
+}
+
+func TestCheck_JSONMissingCoverageExits1WithStdoutPayload(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	initCheckRepo(t, dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "agent", "agent.go"), []byte("package agent\n// new\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, dir, "add", ".")
+	gitInRepo(t, dir, "commit", "-q", "-m", "feat: agent change")
+
+	stdout, stderr, err := runVP(t, "check", "--base", "HEAD~1", "--head", "HEAD", "--json")
+	if err == nil {
+		t.Fatal("vp check --json: want check error, got nil")
+	}
+	coded, ok := errors.AsType[*exitCodeError](err)
+	if !ok || coded.code != exitCheckError {
+		t.Fatalf("vp check --json error = %v (want code %d)", err, exitCheckError)
+	}
+
+	var got checkJSON
+	if uerr := json.Unmarshal(stdout.Bytes(), &got); uerr != nil {
+		t.Fatalf("parse json: %v\nstdout: %s", uerr, stdout.String())
+	}
+	if !slices.Equal(got.Missing, []string{"agent"}) {
+		t.Errorf("missing = %v, want [agent]", got.Missing)
+	}
+	if !slices.Equal(got.Affected, []string{"agent"}) {
+		t.Errorf("affected = %v, want [agent]", got.Affected)
+	}
+	if got.Planned == nil || len(got.Planned) != 0 {
+		t.Errorf("planned = %v, want empty non-nil array", got.Planned)
+	}
+	// Stderr-only contract: error text on stderr; stdout is pure JSON.
+	if strings.Contains(stdout.String(), "missing plan coverage") {
+		t.Errorf("stdout leaked the error message:\n%s", stdout.String())
+	}
+	if stderr.Len() != 0 && !strings.Contains(stderr.String(), "missing plan coverage") {
+		t.Errorf("stderr should mention missing coverage, got:\n%s", stderr.String())
+	}
+}
+
+func TestCheck_JSONEmptyEmitsAllArrays(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	initCheckRepo(t, dir)
+
+	// Touch only vp.yaml — yields zero affected components and no plans.
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(checkTestConfig+"\n# touch\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, dir, "add", ".")
+	gitInRepo(t, dir, "commit", "-q", "-m", "chore: touch config")
+
+	stdout, _, err := runVP(t, "check", "--base", "HEAD~1", "--head", "HEAD", "--json")
+	if err != nil {
+		t.Fatalf("vp check --json: %v", err)
+	}
+	// All three arrays must be present and empty (not null).
+	for _, key := range []string{`"affected": []`, `"planned": []`, `"missing": []`} {
+		if !strings.Contains(stdout.String(), key) {
+			t.Errorf("stdout missing %q\n%s", key, stdout.String())
+		}
+	}
 }
 
 func TestCheck_BogusRefIsRuntimeError(t *testing.T) {

--- a/cmd/golden_json_test.go
+++ b/cmd/golden_json_test.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// These tests pin the exact byte output of `--json` for stable CI consumers.
+// Update with VP_UPDATE_GOLDEN=1 go test ./cmd/...
+
+func TestGolden_StatusEmpty(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeStatusConfig(t, dir)
+
+	stdout, _, err := runVP(t, "status", "--json")
+	if err != nil {
+		t.Fatalf("vp status --json: %v", err)
+	}
+	assertGoldenJSON(t, "status-empty.json", stdout.Bytes())
+}
+
+func TestGolden_StatusPending(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(statusTextConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-fix.yaml",
+		"releases:\n  cli: minor\nmessage: fix the thing\n")
+
+	stdout, _, err := runVP(t, "status", "--json")
+	if err != nil {
+		t.Fatalf("vp status --json: %v", err)
+	}
+	assertGoldenJSON(t, "status-pending.json", stdout.Bytes())
+}
+
+func TestGolden_ApplyDryRun(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeApplyTextConfig(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "apply", "--dry-run", "--json")
+	if err != nil {
+		t.Fatalf("vp apply --dry-run --json: %v", err)
+	}
+	assertGoldenJSON(t, "apply-dryrun.json", stdout.Bytes())
+}
+
+func TestGolden_ApplyLive(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeApplyTextConfig(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "apply", "--json")
+	if err != nil {
+		t.Fatalf("vp apply --json: %v", err)
+	}
+	assertGoldenJSON(t, "apply-live.json", stdout.Bytes())
+}
+
+func TestGolden_ApplyEmpty(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeApplyTextConfig(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := runVP(t, "apply", "--json")
+	if err != nil {
+		t.Fatalf("vp apply --json: %v", err)
+	}
+	assertGoldenJSON(t, "apply-empty.json", stdout.Bytes())
+}
+
+func TestGolden_CheckCovered(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	initCheckRepo(t, dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "cli", "main.go"), []byte("package main\n// changed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-cli.yaml", "releases:\n  cli: minor\n")
+	gitInRepo(t, dir, "add", ".")
+	gitInRepo(t, dir, "commit", "-q", "-m", "feat: cli with plan")
+
+	stdout, _, err := runVP(t, "check", "--base", "HEAD~1", "--head", "HEAD", "--json")
+	if err != nil {
+		t.Fatalf("vp check --json: %v", err)
+	}
+	assertGoldenJSON(t, "check-covered.json", stdout.Bytes())
+}
+
+func TestGolden_CheckMissing(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	initCheckRepo(t, dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "agent", "agent.go"), []byte("package agent\n// new\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitInRepo(t, dir, "add", ".")
+	gitInRepo(t, dir, "commit", "-q", "-m", "feat: agent change")
+
+	stdout, _, _ := runVP(t, "check", "--base", "HEAD~1", "--head", "HEAD", "--json")
+	// Missing-coverage exits non-zero, but stdout still carries the JSON payload.
+	assertGoldenJSON(t, "check-missing.json", stdout.Bytes())
+}

--- a/cmd/golden_test.go
+++ b/cmd/golden_test.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// goldenDir resolves to <cmd-package>/testdata/output/json regardless of the
+// test's current working directory (tests use t.Chdir into temp dirs).
+func goldenDir() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(file), "testdata", "output", "json")
+}
+
+// assertGoldenJSON checks that got matches the bytes in testdata/output/json/<name>.
+// When VP_UPDATE_GOLDEN=1 is set in the environment, the golden file is rewritten
+// instead. Source-of-truth lives in the pinned files: a downstream consumer can
+// inspect or diff them directly.
+func assertGoldenJSON(t *testing.T, name string, got []byte) {
+	t.Helper()
+	dir := goldenDir()
+	path := filepath.Join(dir, name)
+	if os.Getenv("VP_UPDATE_GOLDEN") != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		if err := os.WriteFile(path, got, 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v (run with VP_UPDATE_GOLDEN=1 to create)", path, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("golden mismatch for %s\n--- want ---\n%s\n--- got ---\n%s",
+			path, want, got)
+	}
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -11,8 +11,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ThomasK33/vp/internal/config"
+	"github.com/ThomasK33/vp/internal/output"
+	"github.com/ThomasK33/vp/internal/plan"
 	"github.com/ThomasK33/vp/internal/semver"
+	jsonvf "github.com/ThomasK33/vp/internal/versionfile/json"
 	"github.com/ThomasK33/vp/internal/versionfile/text"
+	tomlvf "github.com/ThomasK33/vp/internal/versionfile/toml"
+	yamlvf "github.com/ThomasK33/vp/internal/versionfile/yaml"
 )
 
 var statusCmd = &cobra.Command{
@@ -40,8 +45,16 @@ var statusCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		jsonOut, err := cmd.Flags().GetBool("json")
+		if err != nil {
+			return err
+		}
 
 		out := cmd.OutOrStdout()
+
+		if jsonOut {
+			return output.WriteStatus(out, buildStatusReport(cfg, pending, collapsed, showAll))
+		}
 
 		if len(pending) == 0 {
 			_, _ = fmt.Fprintln(out, "No pending plans.")
@@ -62,6 +75,72 @@ var statusCmd = &cobra.Command{
 	},
 }
 
+func buildStatusReport(cfg *config.Config, pending []plan.Pending, collapsed map[string]semver.Bump, showAll bool) *output.StatusReport {
+	report := &output.StatusReport{
+		Pending:  make([]output.PendingPlan, 0, len(pending)),
+		Resolved: []output.ResolvedComponent{},
+	}
+	for _, p := range pending {
+		report.Pending = append(report.Pending, output.PendingPlan{
+			File:     filepath.Base(p.Path),
+			Releases: p.Plan.Releases,
+			Message:  p.Plan.Message,
+		})
+	}
+	names := sortedKeys(collapsed)
+	if showAll {
+		names = sortedKeys(cfg.Components)
+	}
+	for _, n := range names {
+		level := collapsed[n]
+		if level == "" {
+			level = semver.BumpNone
+		}
+		entry := output.ResolvedComponent{Component: n, Bump: string(level)}
+		if cur, ok := readVersion(cfg, n); ok {
+			entry.Current = cur
+			if level != semver.BumpNone {
+				if next, err := semver.Next(cur, level); err == nil {
+					entry.Next = next
+				}
+			}
+		}
+		report.Resolved = append(report.Resolved, entry)
+	}
+	return report
+}
+
+// readVersion returns the current version for the named component when its
+// version file is readable. The boolean is false when the format is unknown,
+// the file is missing, or the format-specific parser errors out — mirroring
+// the silent-fallback policy of the text-output path.
+func readVersion(cfg *config.Config, name string) (string, bool) {
+	comp, ok := cfg.Components[name]
+	if !ok {
+		return "", false
+	}
+	var (
+		v   string
+		err error
+	)
+	switch comp.Version.Format {
+	case config.FormatText:
+		v, err = text.Read(comp.Version.File)
+	case config.FormatJSON:
+		v, err = jsonvf.Read(comp.Version.File, comp.Version.Path)
+	case config.FormatYAML:
+		v, err = yamlvf.Read(comp.Version.File, comp.Version.Path)
+	case config.FormatTOML:
+		v, err = tomlvf.Read(comp.Version.File, comp.Version.Path)
+	default:
+		return "", false
+	}
+	if err != nil {
+		return "", false
+	}
+	return v, true
+}
+
 func printSummary(out io.Writer, cfg *config.Config, collapsed map[string]semver.Bump, showAll bool) {
 	names := sortedKeys(collapsed)
 	if showAll {
@@ -77,17 +156,13 @@ func printSummary(out io.Writer, cfg *config.Config, collapsed map[string]semver
 	}
 }
 
-// formatSummaryLine renders one resolved-bump row. For text-format components
-// it appends current/next version info; for any other format (or when reading
-// the version file fails) it falls back to the bare "name: bump" form.
+// formatSummaryLine renders one resolved-bump row. When the component's
+// version file is readable in any supported format, it appends current/next
+// (or current alone for BumpNone); otherwise it falls back to "name: bump".
 func formatSummaryLine(cfg *config.Config, name string, level semver.Bump) string {
 	bare := fmt.Sprintf("%s: %s", name, level)
-	comp, ok := cfg.Components[name]
-	if !ok || comp.Version.Format != config.FormatText {
-		return bare
-	}
-	cur, err := text.Read(comp.Version.File)
-	if err != nil {
+	cur, ok := readVersion(cfg, name)
+	if !ok {
 		return bare
 	}
 	if level == semver.BumpNone {
@@ -111,5 +186,6 @@ func sortedKeys[V any](m map[string]V) []string {
 
 func init() {
 	statusCmd.Flags().Bool("all", false, "show every component from config, not just those with pending bumps")
+	statusCmd.Flags().Bool("json", false, "emit machine-readable JSON to stdout")
 	rootCmd.AddCommand(statusCmd)
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,11 +1,31 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
+
+type statusJSON struct {
+	Pending  []pendingJSON  `json:"pending"`
+	Resolved []resolvedJSON `json:"resolved"`
+}
+
+type pendingJSON struct {
+	File     string            `json:"file"`
+	Releases map[string]string `json:"releases"`
+	Message  string            `json:"message,omitempty"`
+}
+
+type resolvedJSON struct {
+	Component string `json:"component"`
+	Bump      string `json:"bump"`
+	Current   string `json:"current,omitempty"`
+	Next      string `json:"next,omitempty"`
+}
 
 const statusTestConfig = `
 plans:
@@ -251,6 +271,291 @@ func TestStatus_TextComponentMissingFileFallsBack(t *testing.T) {
 	summary := stdout.String()[strings.Index(stdout.String(), "Resolved bumps:"):]
 	if !strings.Contains(summary, "cli: minor") {
 		t.Errorf("summary missing fallback 'cli: minor':\n%s", summary)
+	}
+}
+
+func TestStatus_JSONEmptyEmitsBothArrays(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeStatusConfig(t, dir)
+
+	stdout, _, err := runVP(t, "status", "--json")
+	if err != nil {
+		t.Fatalf("vp status --json: %v", err)
+	}
+
+	var got statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("parse json: %v\nstdout: %s", err, stdout.String())
+	}
+	if got.Pending == nil || len(got.Pending) != 0 {
+		t.Errorf("pending = %v, want empty non-nil array", got.Pending)
+	}
+	if got.Resolved == nil || len(got.Resolved) != 0 {
+		t.Errorf("resolved = %v, want empty non-nil array", got.Resolved)
+	}
+	if !strings.Contains(stdout.String(), `"pending": []`) || !strings.Contains(stdout.String(), `"resolved": []`) {
+		t.Errorf("expected empty arrays in raw JSON, got:\n%s", stdout.String())
+	}
+}
+
+func TestStatus_JSONIncludesPendingAndResolvedSorted(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeStatusConfig(t, dir)
+
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-fix.yaml",
+		"releases:\n  cli: minor\n  agent: none\nmessage: fix\n")
+	writePlanFile(t, plansDir, "2026-05-04-bump.yaml",
+		"releases:\n  cli: patch\n")
+
+	stdout, _, err := runVP(t, "status", "--json")
+	if err != nil {
+		t.Fatalf("vp status --json: %v", err)
+	}
+	var got statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("parse json: %v\nstdout: %s", err, stdout.String())
+	}
+
+	if len(got.Pending) != 2 {
+		t.Fatalf("pending len = %d, want 2\n%s", len(got.Pending), stdout.String())
+	}
+	if got.Pending[0].File != "2026-05-03-fix.yaml" || got.Pending[1].File != "2026-05-04-bump.yaml" {
+		t.Errorf("pending order wrong: %v", []string{got.Pending[0].File, got.Pending[1].File})
+	}
+	if got.Pending[0].Message != "fix" {
+		t.Errorf("first pending message = %q, want %q", got.Pending[0].Message, "fix")
+	}
+	if got.Pending[1].Message != "" {
+		t.Errorf("second pending message = %q, want empty", got.Pending[1].Message)
+	}
+	if got.Pending[0].Releases["cli"] != "minor" || got.Pending[0].Releases["agent"] != "none" {
+		t.Errorf("first pending releases = %v", got.Pending[0].Releases)
+	}
+
+	// Resolved is component-name sorted; cli collapses minor>patch; helm omitted (no plan, no --all).
+	wantNames := []string{"agent", "cli"}
+	gotNames := []string{}
+	for _, r := range got.Resolved {
+		gotNames = append(gotNames, r.Component)
+	}
+	if !slices.Equal(gotNames, wantNames) {
+		t.Errorf("resolved components = %v, want %v", gotNames, wantNames)
+	}
+	for _, r := range got.Resolved {
+		if r.Component == "cli" && r.Bump != "minor" {
+			t.Errorf("cli bump = %q, want minor", r.Bump)
+		}
+		if r.Component == "agent" && r.Bump != "none" {
+			t.Errorf("agent bump = %q, want none", r.Bump)
+		}
+	}
+
+	// Verify omitempty: the second pending entry must have no "message" key.
+	idx := strings.Index(stdout.String(), "2026-05-04-bump.yaml")
+	if idx < 0 {
+		t.Fatalf("second pending entry not found in JSON")
+	}
+	if strings.Contains(stdout.String()[idx:], `"message"`) {
+		t.Errorf("second pending should omit message key:\n%s", stdout.String()[idx:])
+	}
+}
+
+func TestStatus_JSONTextFormatHasCurrentAndNext(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(statusTextConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "status", "--json")
+	if err != nil {
+		t.Fatalf("vp status --json: %v", err)
+	}
+	var got statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	if len(got.Resolved) != 1 {
+		t.Fatalf("resolved len = %d, want 1", len(got.Resolved))
+	}
+	r := got.Resolved[0]
+	if r.Current != "1.2.3" || r.Next != "1.3.0" {
+		t.Errorf("current/next = %q/%q, want 1.2.3/1.3.0", r.Current, r.Next)
+	}
+}
+
+func TestStatus_JSONNoneOmitsNext(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(statusTextConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("1.2.3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-noop.yaml", "releases:\n  cli: none\n")
+
+	stdout, _, err := runVP(t, "status", "--json")
+	if err != nil {
+		t.Fatalf("vp status --json: %v", err)
+	}
+	var got statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	r := got.Resolved[0]
+	if r.Current != "1.2.3" {
+		t.Errorf("current = %q, want 1.2.3", r.Current)
+	}
+	if r.Next != "" {
+		t.Errorf("next should be empty for bump=none, got %q", r.Next)
+	}
+	// raw JSON: ensure "next" key does not appear for the cli entry.
+	if strings.Contains(stdout.String(), `"next"`) {
+		t.Errorf("raw JSON should omit next when bump=none:\n%s", stdout.String())
+	}
+}
+
+func TestStatus_JSONReadFailureOmitsCurrentAndNext(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(statusTextConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// no VERSION file — text reader will fail
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
+
+	stdout, _, err := runVP(t, "status", "--json")
+	if err != nil {
+		t.Fatalf("vp status --json: %v", err)
+	}
+	var got statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	r := got.Resolved[0]
+	if r.Current != "" || r.Next != "" {
+		t.Errorf("expected current/next empty on read failure, got %q/%q", r.Current, r.Next)
+	}
+	if r.Bump != "minor" {
+		t.Errorf("bump = %q, want minor (bump must still appear even when version unreadable)", r.Bump)
+	}
+}
+
+func TestStatus_JSONReadsAllSupportedFormats(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	const cfg = `
+plans:
+  dir: .version-plans
+  consumed: delete
+components:
+  cli:
+    paths: ["cli/**"]
+    version: {file: cli/package.json, format: json, path: version}
+  agent:
+    paths: ["agent/**"]
+    version: {file: agent/Cargo.toml, format: toml, path: package.version}
+  helm:
+    paths: ["chart/**"]
+    version: {file: chart/Chart.yaml, format: yaml, path: version}
+`
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(dir, "cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cli", "package.json"),
+		[]byte(`{"version":"1.2.3"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "agent", "Cargo.toml"),
+		[]byte("[package]\nversion = \"0.4.1\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "chart"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "chart", "Chart.yaml"),
+		[]byte("name: thing\nversion: 2.5.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml",
+		"releases:\n  cli: minor\n  agent: patch\n  helm: major\n")
+
+	stdout, _, err := runVP(t, "status", "--json")
+	if err != nil {
+		t.Fatalf("vp status --json: %v", err)
+	}
+	var got statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("parse json: %v\n%s", err, stdout.String())
+	}
+
+	want := map[string][2]string{
+		"agent": {"0.4.1", "0.4.2"},
+		"cli":   {"1.2.3", "1.3.0"},
+		"helm":  {"2.5.0", "3.0.0"},
+	}
+	for _, r := range got.Resolved {
+		w, ok := want[r.Component]
+		if !ok {
+			continue
+		}
+		if r.Current != w[0] || r.Next != w[1] {
+			t.Errorf("%s current/next = %q/%q, want %q/%q",
+				r.Component, r.Current, r.Next, w[0], w[1])
+		}
+	}
+}
+
+func TestStatus_JSONWithAllShowsEveryComponent(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeStatusConfig(t, dir)
+
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-only-cli.yaml", "releases:\n  cli: patch\n")
+
+	stdout, _, err := runVP(t, "status", "--json", "--all")
+	if err != nil {
+		t.Fatalf("vp status --json --all: %v", err)
+	}
+	var got statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	bumps := map[string]string{}
+	for _, r := range got.Resolved {
+		bumps[r.Component] = r.Bump
+	}
+	for _, want := range []string{"cli", "agent", "helm"} {
+		if _, ok := bumps[want]; !ok {
+			t.Errorf("--all resolved missing %q\n%s", want, stdout.String())
+		}
+	}
+	if bumps["cli"] != "patch" {
+		t.Errorf("cli bump = %q, want patch", bumps["cli"])
+	}
+	if bumps["agent"] != "none" || bumps["helm"] != "none" {
+		t.Errorf("agent/helm bump = %q/%q, want none/none", bumps["agent"], bumps["helm"])
 	}
 }
 

--- a/cmd/testdata/output/json/apply-dryrun.json
+++ b/cmd/testdata/output/json/apply-dryrun.json
@@ -1,0 +1,12 @@
+{
+  "changes": [
+    {
+      "component": "cli",
+      "current": "1.2.3",
+      "next": "1.3.0",
+      "bump": "minor",
+      "file": "VERSION"
+    }
+  ],
+  "consumed": []
+}

--- a/cmd/testdata/output/json/apply-empty.json
+++ b/cmd/testdata/output/json/apply-empty.json
@@ -1,0 +1,4 @@
+{
+  "changes": [],
+  "consumed": []
+}

--- a/cmd/testdata/output/json/apply-live.json
+++ b/cmd/testdata/output/json/apply-live.json
@@ -1,0 +1,14 @@
+{
+  "changes": [
+    {
+      "component": "cli",
+      "current": "1.2.3",
+      "next": "1.3.0",
+      "bump": "minor",
+      "file": "VERSION"
+    }
+  ],
+  "consumed": [
+    "2026-05-03-bump.yaml"
+  ]
+}

--- a/cmd/testdata/output/json/check-covered.json
+++ b/cmd/testdata/output/json/check-covered.json
@@ -1,0 +1,9 @@
+{
+  "affected": [
+    "cli"
+  ],
+  "planned": [
+    "cli"
+  ],
+  "missing": []
+}

--- a/cmd/testdata/output/json/check-missing.json
+++ b/cmd/testdata/output/json/check-missing.json
@@ -1,0 +1,9 @@
+{
+  "affected": [
+    "agent"
+  ],
+  "planned": [],
+  "missing": [
+    "agent"
+  ]
+}

--- a/cmd/testdata/output/json/status-empty.json
+++ b/cmd/testdata/output/json/status-empty.json
@@ -1,0 +1,4 @@
+{
+  "pending": [],
+  "resolved": []
+}

--- a/cmd/testdata/output/json/status-pending.json
+++ b/cmd/testdata/output/json/status-pending.json
@@ -1,0 +1,19 @@
+{
+  "pending": [
+    {
+      "file": "2026-05-03-fix.yaml",
+      "releases": {
+        "cli": "minor"
+      },
+      "message": "fix the thing"
+    }
+  ],
+  "resolved": [
+    {
+      "component": "cli",
+      "bump": "minor",
+      "current": "1.2.3",
+      "next": "1.3.0"
+    }
+  ]
+}

--- a/internal/output/apply.go
+++ b/internal/output/apply.go
@@ -1,0 +1,38 @@
+package output
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// ApplyReport is the JSON shape emitted by `vp apply --json` and
+// `vp apply --dry-run --json`. The two modes share a single shape;
+// dry-run emits Consumed as an empty array.
+type ApplyReport struct {
+	Changes  []Change `json:"changes"`
+	Consumed []string `json:"consumed"`
+}
+
+// Change is one component's planned or applied version-file write.
+type Change struct {
+	Component string `json:"component"`
+	Current   string `json:"current"`
+	Next      string `json:"next"`
+	Bump      string `json:"bump"`
+	File      string `json:"file"`
+	Tag       string `json:"tag,omitempty"`
+}
+
+// WriteApply encodes r to w as pretty-printed JSON with a trailing newline.
+// Nil slices in r are written as empty arrays so consumers see a stable shape.
+func WriteApply(w io.Writer, r *ApplyReport) error {
+	if r.Changes == nil {
+		r.Changes = []Change{}
+	}
+	if r.Consumed == nil {
+		r.Consumed = []string{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}

--- a/internal/output/check.go
+++ b/internal/output/check.go
@@ -1,0 +1,31 @@
+package output
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// CheckReport is the JSON shape emitted by `vp check --json`.
+type CheckReport struct {
+	Affected []string `json:"affected"`
+	Planned  []string `json:"planned"`
+	Missing  []string `json:"missing"`
+}
+
+// WriteCheck encodes r to w as pretty-printed JSON with a trailing newline.
+// Nil slices in r are written as empty arrays so consumers see a stable shape.
+func WriteCheck(w io.Writer, r *CheckReport) error {
+	r.Affected = nilToEmpty(r.Affected)
+	r.Planned = nilToEmpty(r.Planned)
+	r.Missing = nilToEmpty(r.Missing)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+func nilToEmpty(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}

--- a/internal/output/status.go
+++ b/internal/output/status.go
@@ -1,0 +1,42 @@
+package output
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// StatusReport is the JSON shape emitted by `vp status --json`.
+type StatusReport struct {
+	Pending  []PendingPlan       `json:"pending"`
+	Resolved []ResolvedComponent `json:"resolved"`
+}
+
+// PendingPlan describes one plan file currently sitting in the plans dir.
+type PendingPlan struct {
+	File     string            `json:"file"`
+	Releases map[string]string `json:"releases"`
+	Message  string            `json:"message,omitempty"`
+}
+
+// ResolvedComponent is one component's collapsed bump and (when readable)
+// the current and next version strings.
+type ResolvedComponent struct {
+	Component string `json:"component"`
+	Bump      string `json:"bump"`
+	Current   string `json:"current,omitempty"`
+	Next      string `json:"next,omitempty"`
+}
+
+// WriteStatus encodes r to w as pretty-printed JSON with a trailing newline.
+// Nil slices in r are written as empty arrays so consumers see a stable shape.
+func WriteStatus(w io.Writer, r *StatusReport) error {
+	if r.Pending == nil {
+		r.Pending = []PendingPlan{}
+	}
+	if r.Resolved == nil {
+		r.Resolved = []ResolvedComponent{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}


### PR DESCRIPTION
## Summary

- Adds opt-in `--json` flag to `vp status`, `vp apply` (incl. `--dry-run`), and `vp check`. Plain text remains the default; errors stay on stderr unchanged.
- Pins the JSON schema with golden files under `cmd/testdata/output/json/` (regenerate via `VP_UPDATE_GOLDEN=1 go test ./cmd/...`) and documents it in the README.
- Status JSON now reads `text`, `json`, `yaml`, and `toml` version files when populating `current`/`next` (shared `readVersion` helper also lets text-mode status show current/next for non-text formats).

Closes #12.

## Test plan

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] Manual smoke test: `vp status --json`, `vp apply --dry-run --json`, `vp apply --json`, `vp check --json` all produce documented shapes; error paths leave stdout empty with messages on stderr; missing-coverage exits 1 with JSON payload on stdout
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)