### PR TITLE
Slice 13: vp apply dispatches JSON/YAML/TOML writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,6 @@ Resolved bumps:
   rust-agent: none (0.9.0)
 ```
 
-> **Known limitation (v0.x).** `vp apply` currently writes only
-> text-format version files. Read paths for `json`/`yaml`/`toml`
-> already work — `vp status` will show current and next versions for
-> all four — but applying writes is on the roadmap. Until then, use
-> `text`-format version files (e.g. a one-line `VERSION` file per
-> component) for components you intend to release with `vp apply`.
-
 ## Release flow with a separate changelog tool
 
 `vp` prints intended tag strings; your release pipeline executes them.

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -16,7 +16,10 @@ import (
 	"github.com/ThomasK33/vp/internal/output"
 	"github.com/ThomasK33/vp/internal/plan"
 	"github.com/ThomasK33/vp/internal/semver"
+	jsonvf "github.com/ThomasK33/vp/internal/versionfile/json"
 	"github.com/ThomasK33/vp/internal/versionfile/text"
+	tomlvf "github.com/ThomasK33/vp/internal/versionfile/toml"
+	yamlvf "github.com/ThomasK33/vp/internal/versionfile/yaml"
 )
 
 type plannedChange struct {
@@ -25,6 +28,8 @@ type plannedChange struct {
 	current string
 	next    string
 	file    string
+	format  string
+	path    string
 	tag     string
 }
 
@@ -81,7 +86,20 @@ var applyCmd = &cobra.Command{
 		}
 
 		for _, ch := range changes {
-			if err := text.Write(ch.file, ch.next); err != nil {
+			var err error
+			switch ch.format {
+			case config.FormatText:
+				err = text.Write(ch.file, ch.next)
+			case config.FormatJSON:
+				err = jsonvf.Write(ch.file, ch.path, ch.next)
+			case config.FormatYAML:
+				err = yamlvf.Write(ch.file, ch.path, ch.next)
+			case config.FormatTOML:
+				err = tomlvf.Write(ch.file, ch.path, ch.next)
+			default:
+				return fmt.Errorf("component %q: unsupported version format %q", ch.name, ch.format)
+			}
+			if err != nil {
 				return err
 			}
 		}
@@ -131,13 +149,22 @@ func planChanges(cfg *config.Config, collapsed map[string]semver.Bump) ([]planne
 			continue
 		}
 		comp := cfg.Components[name]
-		if comp.Version.Format != config.FormatText {
-			return nil, fmt.Errorf(
-				"component %q: version file format %q not yet supported (text only in this release)",
-				name, comp.Version.Format,
-			)
+		var (
+			cur string
+			err error
+		)
+		switch comp.Version.Format {
+		case config.FormatText:
+			cur, err = text.Read(comp.Version.File)
+		case config.FormatJSON:
+			cur, err = jsonvf.Read(comp.Version.File, comp.Version.Path)
+		case config.FormatYAML:
+			cur, err = yamlvf.Read(comp.Version.File, comp.Version.Path)
+		case config.FormatTOML:
+			cur, err = tomlvf.Read(comp.Version.File, comp.Version.Path)
+		default:
+			return nil, fmt.Errorf("component %q: unsupported version format %q", name, comp.Version.Format)
 		}
-		cur, err := text.Read(comp.Version.File)
 		if err != nil {
 			return nil, err
 		}
@@ -151,6 +178,8 @@ func planChanges(cfg *config.Config, collapsed map[string]semver.Bump) ([]planne
 			current: cur,
 			next:    next,
 			file:    comp.Version.File,
+			format:  comp.Version.Format,
+			path:    comp.Version.Path,
 			tag:     renderTag(comp.Tag, next),
 		})
 	}

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -34,6 +34,98 @@ components:
     version: {file: VERSION, format: text}
 `
 
+const applyMultiFormatVPYAML = `
+plans:
+  dir: .version-plans
+  consumed: delete
+components:
+  txt:
+    paths: ["txt/**"]
+    version: {file: txt/VERSION, format: text}
+  js:
+    paths: ["js/**"]
+    version: {file: js/package.json, format: json, path: version}
+  yml:
+    paths: ["yml/**"]
+    version: {file: yml/Chart.yaml, format: yaml, path: version}
+  tml:
+    paths: ["tml/**"]
+    version: {file: tml/Cargo.toml, format: toml, path: package.version}
+`
+
+const (
+	applyMultiFormatVERSIONBefore = "1.2.3\n"
+	applyMultiFormatVERSIONAfter  = "1.3.0\n"
+
+	applyMultiFormatPackageJSONBefore = `{
+  "name": "thing",
+  "version": "1.2.3",
+  "scripts": {
+    "build": "echo build"
+  }
+}
+`
+	applyMultiFormatPackageJSONAfter = `{
+  "name": "thing",
+  "version": "1.2.4",
+  "scripts": {
+    "build": "echo build"
+  }
+}
+`
+
+	applyMultiFormatChartYAMLBefore = `# Helm chart for thing
+apiVersion: v2
+name: thing
+version: 2.5.0
+description: example chart
+`
+	applyMultiFormatChartYAMLAfter = `# Helm chart for thing
+apiVersion: v2
+name: thing
+version: 3.0.0
+description: example chart
+`
+
+	applyMultiFormatCargoTOMLBefore = `# Rust crate
+[package]
+name = "thing"
+version = "0.4.1"
+
+[dependencies]
+serde = "1"
+`
+	applyMultiFormatCargoTOMLAfter = `# Rust crate
+[package]
+name = "thing"
+version = "0.5.0"
+
+[dependencies]
+serde = "1"
+`
+)
+
+func writeMultiFormatFixture(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(applyMultiFormatVPYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []struct{ rel, content string }{
+		{"txt/VERSION", applyMultiFormatVERSIONBefore},
+		{"js/package.json", applyMultiFormatPackageJSONBefore},
+		{"yml/Chart.yaml", applyMultiFormatChartYAMLBefore},
+		{"tml/Cargo.toml", applyMultiFormatCargoTOMLBefore},
+	} {
+		path := filepath.Join(dir, f.rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(f.content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func writeApplyTextConfig(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(applyTestConfigText), 0o600); err != nil {
@@ -493,27 +585,6 @@ func TestApply_UnknownComponentInPlan(t *testing.T) {
 	}
 }
 
-func TestApply_RejectsNonTextFormatWithBump(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-	if err := os.WriteFile(filepath.Join(dir, "vp.yaml"), []byte(statusTestConfig), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	plansDir := filepath.Join(dir, ".version-plans")
-	writePlanFile(t, plansDir, "2026-05-03-bump.yaml", "releases:\n  cli: minor\n")
-
-	_, _, err := runVP(t, "apply")
-	if err == nil {
-		t.Fatal("vp apply: want error, got nil")
-	}
-	if !strings.Contains(err.Error(), "not yet supported") {
-		t.Errorf("error = %v, want it to mention 'not yet supported'", err)
-	}
-	if _, err := os.Stat(filepath.Join(plansDir, "2026-05-03-bump.yaml")); err != nil {
-		t.Errorf("plan removed despite Phase 1 failure: %v", err)
-	}
-}
-
 func TestApply_RejectsMissingVersionFile(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -588,5 +659,84 @@ func TestApply_HappyPathWritesAndConsumes(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("stdout missing %q\n---\n%s", want, out)
 		}
+	}
+}
+
+func TestApply_WritesAllSupportedFormats(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeMultiFormatFixture(t, dir)
+
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml",
+		"releases:\n  txt: minor\n  js: patch\n  yml: major\n  tml: minor\n")
+
+	if _, _, err := runVP(t, "apply"); err != nil {
+		t.Fatalf("vp apply: %v", err)
+	}
+
+	for _, f := range []struct{ rel, want string }{
+		{"txt/VERSION", applyMultiFormatVERSIONAfter},
+		{"js/package.json", applyMultiFormatPackageJSONAfter},
+		{"yml/Chart.yaml", applyMultiFormatChartYAMLAfter},
+		{"tml/Cargo.toml", applyMultiFormatCargoTOMLAfter},
+	} {
+		got, err := os.ReadFile(filepath.Join(dir, f.rel))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != f.want {
+			t.Errorf("%s after apply mismatch\n--- got ---\n%s\n--- want ---\n%s", f.rel, got, f.want)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(plansDir, "2026-05-03-bump.yaml")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("plan should have been consumed: %v", err)
+	}
+}
+
+func TestApply_DryRunReadsAllFormats(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeMultiFormatFixture(t, dir)
+
+	plansDir := filepath.Join(dir, ".version-plans")
+	planPath := filepath.Join(plansDir, "2026-05-03-bump.yaml")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml",
+		"releases:\n  txt: minor\n  js: patch\n  yml: major\n  tml: minor\n")
+
+	stdout, _, err := runVP(t, "apply", "--dry-run")
+	if err != nil {
+		t.Fatalf("vp apply --dry-run: %v", err)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"txt", "1.2.3", "1.3.0",
+		"js", "1.2.4",
+		"yml", "2.5.0", "3.0.0",
+		"tml", "0.4.1", "0.5.0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run stdout missing %q\n---\n%s", want, out)
+		}
+	}
+
+	for _, f := range []struct{ rel, want string }{
+		{"txt/VERSION", applyMultiFormatVERSIONBefore},
+		{"js/package.json", applyMultiFormatPackageJSONBefore},
+		{"yml/Chart.yaml", applyMultiFormatChartYAMLBefore},
+		{"tml/Cargo.toml", applyMultiFormatCargoTOMLBefore},
+	} {
+		got, err := os.ReadFile(filepath.Join(dir, f.rel))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != f.want {
+			t.Errorf("%s changed during dry-run\n--- got ---\n%s", f.rel, got)
+		}
+	}
+	if _, err := os.Stat(planPath); err != nil {
+		t.Errorf("plan file consumed during dry-run: %v", err)
 	}
 }

--- a/cmd/golden_json_test.go
+++ b/cmd/golden_json_test.go
@@ -75,6 +75,21 @@ func TestGolden_ApplyLive(t *testing.T) {
 	assertGoldenJSON(t, "apply-live.json", stdout.Bytes())
 }
 
+func TestGolden_ApplyMultiFormat(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeMultiFormatFixture(t, dir)
+	plansDir := filepath.Join(dir, ".version-plans")
+	writePlanFile(t, plansDir, "2026-05-03-bump.yaml",
+		"releases:\n  txt: minor\n  js: patch\n  yml: major\n  tml: minor\n")
+
+	stdout, _, err := runVP(t, "apply", "--json")
+	if err != nil {
+		t.Fatalf("vp apply --json: %v", err)
+	}
+	assertGoldenJSON(t, "apply-multiformat.json", stdout.Bytes())
+}
+
 func TestGolden_ApplyEmpty(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/cmd/testdata/output/json/apply-multiformat.json
+++ b/cmd/testdata/output/json/apply-multiformat.json
@@ -1,0 +1,35 @@
+{
+  "changes": [
+    {
+      "component": "js",
+      "current": "1.2.3",
+      "next": "1.2.4",
+      "bump": "patch",
+      "file": "js/package.json"
+    },
+    {
+      "component": "tml",
+      "current": "0.4.1",
+      "next": "0.5.0",
+      "bump": "minor",
+      "file": "tml/Cargo.toml"
+    },
+    {
+      "component": "txt",
+      "current": "1.2.3",
+      "next": "1.3.0",
+      "bump": "minor",
+      "file": "txt/VERSION"
+    },
+    {
+      "component": "yml",
+      "current": "2.5.0",
+      "next": "3.0.0",
+      "bump": "major",
+      "file": "yml/Chart.yaml"
+    }
+  ],
+  "consumed": [
+    "2026-05-03-bump.yaml"
+  ]
+}


### PR DESCRIPTION
## Summary

- Removes the text-only restriction in `vp apply` so a single config can mix `text`, `json`, `yaml`, and `toml` components in one run; mirrors the existing read-dispatch in `cmd/status.go`.
- Surgical writes are preserved per ADR-0002 — comments, key order, indentation, anchors, trailing newlines, and sibling values are kept intact by the per-format `Write` functions, which this slice consumes unchanged.
- `vp apply --dry-run` now reads through the same dispatch, so the dry-run table shows current/next pairs for every supported format.
- Drops the v0.x "Known limitation" callout in the README's worked-example section.

Closes #27.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `TestApply_WritesAllSupportedFormats` — multi-format fixture, byte-equal post-apply assertions, plan consumed.
- [x] `TestApply_DryRunReadsAllFormats` — current/next visible for all four formats, files & plan untouched.
- [x] `TestGolden_ApplyMultiFormat` — pinned `--json` payload at `cmd/testdata/output/json/apply-multiformat.json` (regenerate with `VP_UPDATE_GOLDEN=1`).
- [x] Obsolete `TestApply_RejectsNonTextFormatWithBump` removed; existing single-format apply goldens (`apply-{empty,dryrun,live}.json`) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)